### PR TITLE
fix: text anchor lookup recurses into table cells + block-level SDT (Refs PsychQuant/che-word-mcp#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ All notable changes to ooxml-swift will be documented in this file.
 
 - **v0.19.4** (never tagged) — The R3 stack-completion content originally targeted v0.19.4. After the round-3 fix landed, the round-4 6-AI verify (https://github.com/PsychQuant/che-word-mcp/issues/56#issuecomment-4321562429) returned BLOCK with 6 new P0 + 7 P1 findings (walker-asymmetry follow-ups, `position == 0` sentinel collision, attribute-escape sweep gap, block-level SDT typed-Revision propagation, container-symmetric `replaceText`, container `<w:tbl>` parser drop). v0.19.4 was held back. v0.19.5 ships the R3 stack content (preserved verbatim below) **plus** the R5 stack-completion fixes (6 P0 + 5 P1, additive — no breaking change versus the v0.19.4 contract). No v0.19.4 git tag, no v0.19.4 GitHub Release.
 
+## [0.20.6] - 2026-04-28
+
+### Fixed — Text anchor lookup recurses into table cells + block-level SDT (Refs PsychQuant/che-word-mcp#68)
+
+`InsertLocation.findBodyChildContainingText` (used by `.afterText` / `.beforeText` resolution in `insertParagraph`) previously only iterated `.paragraph` BodyChild cases. Anchor text inside a table cell or block-level `<w:sdt>` was silently skipped → `textNotFound` thrown even though the text was present. Real-world thesis docs (figure / table captions inside table cells) became unanchorable.
+
+#### What changed
+
+- New private static helper `bodyChildContainsText(_:needle:)` walks `.paragraph` (via `flattenedDisplayText()`, post-#63 inline-SDT coverage), `.table` (via `tableContainsText` over `rows[].cells[].paragraphs` + `cell.nestedTables`), and `.contentControl(_, children:)` (recursive on the children list).
+- `findBodyChildContainingText` now uses this helper for the per-BodyChild check; counting rule preserved (1 top-level BodyChild containing the needle = 1 `nthInstance` count, regardless of how many nested paragraphs match — same semantic as pre-fix multi-occurrence within ONE paragraph).
+- Returned idx is still the TOP-LEVEL `body.children` index, so `.afterText` / `.beforeText` insert at body level adjacent to the entire containing table/SDT, not inside its cells/children. (Use `.intoTableCell` for inside-cell inserts.)
+- New empty-needle guard: `findBodyChildContainingText` returns nil for `needle.isEmpty` (pre-fix `String.contains("")` returned true → silent insert at idx 1).
+
+#### Tests
+
+10 new sub-tests in `Issue68TextAnchorTraversalTests`:
+- 1-level table cell paragraph
+- Nested table (`cell.nestedTables`) paragraph
+- Block-level SDT child paragraph
+- Nested block SDT (SDT > SDT > paragraph)
+- Mixed nesting (SDT > table > cell > paragraph)
+- nthInstance ordering across paragraph + table + SDT
+- Multi-cell counting pin (1 table with 3 needle cells = 1 instance)
+- Empty needle throws `textNotFound`
+- Pre-existing inline SDT path (regression pin via `flattenedDisplayText`)
+- `textNotFound` still throws for absent needle
+
+Suite: `696 → 706` (+10, 0 fail / 1 skip).
+
+#### Out of scope (verify-68 follow-ups)
+
+- **Parser-side SDT depth limit**: `DocxReader.parseBodyChildren` recurses into `<w:sdt>` children with no explicit depth cap (table nesting is parser-depth-limited to 5 at `Table.swift:80`). Verify-68 DA flagged as P1 pre-existing risk. The new `bodyChildContainsText` adds 2 stack frames per SDT level, amplifying the existing surface but not introducing it. Track separately.
+- **Headers / footers / footnotes / endnotes**: those parts have their own `bodyChildren` collections (`Footnote.swift:121`, etc.); the helper only walks `body.children`. Anchor text inside headers/footers/footnote bodies is still unfindable. #68 scope was explicitly body-level traversal; cross-part anchor lookup is a separate enhancement.
+- **`.bookmarkMarker` / `.rawBlockElement` (vendor extensions)**: silently return false. Acceptable since vendor extension content is opaque by design.
+
+#### Backward compatibility
+
+Strict superset of pre-fix behavior: anchor lookup now succeeds in MORE cases (table cells + block SDT). No callers should depend on the prior `textNotFound` for those locations. No public API change.
+
 ## [0.20.3] - 2026-04-27
 
 ### Added — Sub-stack E of paragraph-level content-equality (closes #66)

--- a/Sources/OOXMLSwift/Models/InsertLocation.swift
+++ b/Sources/OOXMLSwift/Models/InsertLocation.swift
@@ -163,14 +163,57 @@ extension WordDocument {
         guard nthInstance >= 1 else { return nil }
         var seen = 0
         for (i, child) in body.children.enumerated() {
-            if case .paragraph(let para) = child {
-                if para.flattenedDisplayText().contains(needle) {
-                    seen += 1
-                    if seen == nthInstance { return i }
-                }
+            if Self.bodyChildContainsText(child, needle: needle) {
+                seen += 1
+                if seen == nthInstance { return i }
             }
         }
         return nil
+    }
+
+    /// PsychQuant/che-word-mcp#68 — recursive descent for text-anchor lookup.
+    /// Returns `true` if any paragraph anywhere inside `child` contains `needle`
+    /// (via `Paragraph.flattenedDisplayText()`, which already covers inline SDT
+    /// per #63). Caller (`findBodyChildContainingText`) treats one matching
+    /// top-level BodyChild as ONE `nthInstance` count regardless of how many
+    /// nested paragraphs match — consistent with pre-fix top-level paragraph
+    /// behavior where multi-occurrence within one paragraph counts once.
+    ///
+    /// Surfaces walked:
+    /// - `.paragraph` — direct text via `flattenedDisplayText()`
+    /// - `.table` — `rows[].cells[].paragraphs[]` + `cells[].nestedTables[]`
+    ///   (parser depth-limited to 5; recursion depth bounded by parser)
+    /// - `.contentControl(_, children:)` — recurse on each child via this helper
+    /// - `.bookmarkMarker`, raw catch-all — no text content; returns false
+    private static func bodyChildContainsText(_ child: BodyChild, needle: String) -> Bool {
+        switch child {
+        case .paragraph(let para):
+            return para.flattenedDisplayText().contains(needle)
+        case .table(let table):
+            return tableContainsText(table, needle: needle)
+        case .contentControl(_, let kids):
+            return kids.contains { bodyChildContainsText($0, needle: needle) }
+        case .bookmarkMarker:
+            return false
+        case .rawBlockElement:
+            return false
+        }
+    }
+
+    /// Walks every paragraph in every cell of every row, then recurses into
+    /// `nestedTables`. Returns true on first match (short-circuit).
+    private static func tableContainsText(_ table: Table, needle: String) -> Bool {
+        for row in table.rows {
+            for cell in row.cells {
+                for para in cell.paragraphs {
+                    if para.flattenedDisplayText().contains(needle) { return true }
+                }
+                for nested in cell.nestedTables {
+                    if tableContainsText(nested, needle: needle) { return true }
+                }
+            }
+        }
+        return false
     }
 }
 

--- a/Sources/OOXMLSwift/Models/InsertLocation.swift
+++ b/Sources/OOXMLSwift/Models/InsertLocation.swift
@@ -159,8 +159,23 @@ extension WordDocument {
     /// `<mc:AlternateContent>` silently threw `textNotFound`. Now mirrors the
     /// surface coverage of `Document.replaceInParagraphSurfaces` so the LOOKUP
     /// path matches the REPLACE path.
+    /// Returns the **top-level** `body.children` index of the BodyChild whose
+    /// any descendant paragraph contains `needle` for the `nthInstance`-th
+    /// match, or `nil` if not found / inputs invalid.
+    ///
+    /// **Counting rule (#68)**: each top-level BodyChild that contains the
+    /// needle ANYWHERE inside it counts as ONE `nthInstance` (e.g., a table
+    /// with the needle in 5 cells = 1 instance, not 5). This mirrors the
+    /// pre-#68 behavior where multi-occurrence within ONE top-level
+    /// `.paragraph` also counted as 1.
+    ///
+    /// **Insert-position consequence (#68 — caller `.afterText` / `.beforeText`)**:
+    /// returned idx is top-level, so when needle is inside a `.table` /
+    /// `.contentControl`, the new paragraph lands AT BODY LEVEL adjacent to
+    /// the entire table/SDT — NOT inside the table cell or SDT child list.
+    /// This is intentional: `.intoTableCell` exists for inside-cell inserts.
     private func findBodyChildContainingText(_ needle: String, nthInstance: Int) -> Int? {
-        guard nthInstance >= 1 else { return nil }
+        guard nthInstance >= 1, !needle.isEmpty else { return nil }
         var seen = 0
         for (i, child) in body.children.enumerated() {
             if Self.bodyChildContainsText(child, needle: needle) {

--- a/Tests/OOXMLSwiftTests/Issue68TextAnchorTraversalTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue68TextAnchorTraversalTests.swift
@@ -1,0 +1,262 @@
+import XCTest
+@testable import OOXMLSwift
+
+/// PsychQuant/che-word-mcp#68 — text anchor lookup must traverse table-cell
+/// paragraphs and block-level SDT children.
+///
+/// Pre-fix `findBodyChildContainingText` only iterated `.paragraph` BodyChild
+/// cases (post-#63 it correctly handled inline SDT inside paragraphs via
+/// `flattenedDisplayText`, but `.table` and block-level `.contentControl`
+/// BodyChild were silently skipped — anchor text inside a table cell or block
+/// SDT child was not findable, causing `textNotFound` even though the text
+/// was present in the document).
+///
+/// All tests drive the public API via `insertParagraph(at: .afterText)` so
+/// the private traversal helper is exercised end-to-end. Returned positions
+/// must always be the **top-level** `body.children` index of the BodyChild
+/// containing the match (not a nested index inside table/SDT).
+final class Issue68TextAnchorTraversalTests: XCTestCase {
+
+    // MARK: - .table recursion
+
+    /// Anchor text in a 1-level table cell paragraph: must find and return
+    /// the table's body-level index (so insert places new paragraph AFTER
+    /// the table at body level, not nested inside the cell).
+    func testAfterTextFindsAnchorInTableCellParagraph() throws {
+        var doc = WordDocument()
+        let cell = TableCell(paragraphs: [Paragraph(text: "anchor inside cell")])
+        let row = TableRow(cells: [cell])
+        let table = Table(rows: [row])
+        doc.body.children = [
+            .paragraph(Paragraph(text: "before-table")),
+            .table(table),
+            .paragraph(Paragraph(text: "after-table")),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "inserted"),
+            at: .afterText("anchor inside cell", instance: 1)
+        )
+
+        // Insert lands at index 2 (right after the .table at index 1).
+        XCTAssertEqual(doc.body.children.count, 4)
+        guard case .paragraph(let p) = doc.body.children[2] else {
+            XCTFail("Expected inserted paragraph after table; got \(doc.body.children[2])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "inserted")
+    }
+
+    /// Anchor in nested table cell (table > row > cell > nestedTable > row > cell > para):
+    /// must still return the TOP-LEVEL table body idx, not the nested table.
+    func testAfterTextFindsAnchorInNestedTableCellParagraph() throws {
+        var doc = WordDocument()
+
+        var nestedCell = TableCell(paragraphs: [Paragraph(text: "deep anchor")])
+        nestedCell.properties = TableCellProperties()
+        let nestedRow = TableRow(cells: [nestedCell])
+        let nestedTable = Table(rows: [nestedRow])
+
+        var outerCell = TableCell(paragraphs: [Paragraph(text: "outer cell text")])
+        outerCell.nestedTables = [nestedTable]
+        let outerRow = TableRow(cells: [outerCell])
+        let outerTable = Table(rows: [outerRow])
+
+        doc.body.children = [
+            .paragraph(Paragraph(text: "before")),
+            .table(outerTable),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "inserted-deep"),
+            at: .afterText("deep anchor", instance: 1)
+        )
+
+        // outerTable is at body idx 1; insert should land at idx 2.
+        XCTAssertEqual(doc.body.children.count, 3)
+        guard case .paragraph(let p) = doc.body.children[2] else {
+            XCTFail("Expected paragraph at body idx 2; got \(doc.body.children[2])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "inserted-deep")
+    }
+
+    // MARK: - .contentControl (block-level SDT) recursion
+
+    /// Anchor text in a block-level SDT's child paragraph: must find and
+    /// return the SDT's body idx so insert lands after the SDT at body level.
+    func testAfterTextFindsAnchorInBlockSDTChildParagraph() throws {
+        var doc = WordDocument()
+
+        let sdt101 = StructuredDocumentTag(id: 101, tag: "t101", alias: "T101", type: .plainText)
+
+        let cc = ContentControl(sdt: sdt101, content: "")
+        let sdtChildren: [BodyChild] = [
+            .paragraph(Paragraph(text: "sdt-child anchor"))
+        ]
+        doc.body.children = [
+            .paragraph(Paragraph(text: "before-sdt")),
+            .contentControl(cc, children: sdtChildren),
+            .paragraph(Paragraph(text: "after-sdt")),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "inserted-after-sdt"),
+            at: .afterText("sdt-child anchor", instance: 1)
+        )
+
+        XCTAssertEqual(doc.body.children.count, 4)
+        guard case .paragraph(let p) = doc.body.children[2] else {
+            XCTFail("Expected paragraph at body idx 2; got \(doc.body.children[2])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "inserted-after-sdt")
+    }
+
+    /// Block SDT containing nested block SDT containing paragraph — recursion
+    /// must walk the inner children list.
+    func testAfterTextFindsAnchorInNestedBlockSDT() throws {
+        var doc = WordDocument()
+
+        let sdt102 = StructuredDocumentTag(id: 102, tag: "t102", alias: "T102", type: .plainText)
+
+        let inner = ContentControl(sdt: sdt102, content: "")
+        let sdt103 = StructuredDocumentTag(id: 103, tag: "t103", alias: "T103", type: .plainText)
+        let outer = ContentControl(sdt: sdt103, content: "")
+        let innerChildren: [BodyChild] = [
+            .paragraph(Paragraph(text: "deeply nested sdt anchor"))
+        ]
+        let outerChildren: [BodyChild] = [
+            .contentControl(inner, children: innerChildren)
+        ]
+        doc.body.children = [
+            .contentControl(outer, children: outerChildren),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "found-deeply"),
+            at: .afterText("deeply nested sdt anchor", instance: 1)
+        )
+
+        // outer SDT at body idx 0; insert should land at idx 1.
+        XCTAssertEqual(doc.body.children.count, 2)
+        guard case .paragraph(let p) = doc.body.children[1] else {
+            XCTFail("Expected paragraph at body idx 1; got \(doc.body.children[1])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "found-deeply")
+    }
+
+    // MARK: - Mixed nesting (.contentControl > .table > cell > paragraph)
+
+    func testAfterTextFindsAnchorInBlockSDTContainingTable() throws {
+        var doc = WordDocument()
+        let cell = TableCell(paragraphs: [Paragraph(text: "sdt > table > cell anchor")])
+        let row = TableRow(cells: [cell])
+        let table = Table(rows: [row])
+        let sdt104 = StructuredDocumentTag(id: 104, tag: "t104", alias: "T104", type: .plainText)
+        let cc = ContentControl(sdt: sdt104, content: "")
+        let sdtChildren: [BodyChild] = [.table(table)]
+        doc.body.children = [
+            .paragraph(Paragraph(text: "lead")),
+            .contentControl(cc, children: sdtChildren),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "after-sdt-with-table"),
+            at: .afterText("sdt > table > cell anchor", instance: 1)
+        )
+
+        XCTAssertEqual(doc.body.children.count, 3)
+        guard case .paragraph(let p) = doc.body.children[2] else {
+            XCTFail("Expected paragraph at body idx 2; got \(doc.body.children[2])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "after-sdt-with-table")
+    }
+
+    // MARK: - nthInstance ordering across mixed locations
+
+    /// Multiple matches across paragraph + table cell + SDT: nthInstance
+    /// must count in document order (depth-first per top-level BodyChild).
+    func testAfterTextNthInstanceAcrossMixedLocations() throws {
+        var doc = WordDocument()
+        let cellPara = TableCell(paragraphs: [Paragraph(text: "needle in cell")])
+        let table = Table(rows: [TableRow(cells: [cellPara])])
+
+        let sdt105 = StructuredDocumentTag(id: 105, tag: "t105", alias: "T105", type: .plainText)
+
+        let cc = ContentControl(sdt: sdt105, content: "")
+        let sdtChildren: [BodyChild] = [.paragraph(Paragraph(text: "needle in sdt"))]
+
+        doc.body.children = [
+            .paragraph(Paragraph(text: "needle at top")),     // instance 1 (idx 0)
+            .table(table),                                    // instance 2 (idx 1)
+            .contentControl(cc, children: sdtChildren),       // instance 3 (idx 2)
+            .paragraph(Paragraph(text: "trailer")),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "after-2nd"),
+            at: .afterText("needle", instance: 2)
+        )
+
+        // 2nd "needle" is in the table (idx 1); insert at idx 2.
+        XCTAssertEqual(doc.body.children.count, 5)
+        guard case .paragraph(let p) = doc.body.children[2] else {
+            XCTFail("Expected paragraph after 2nd-instance table; got \(doc.body.children[2])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "after-2nd")
+    }
+
+    // MARK: - Regression pin: pre-existing behavior
+
+    /// #63 inline-SDT anchor (text inside paragraph.contentControls) still works.
+    func testInlineSDTAnchorStillFindsViaFlattenedDisplayText() throws {
+        var doc = WordDocument()
+        var para = Paragraph()
+        let sdt106 = StructuredDocumentTag(id: 106, tag: "t106", alias: "T106", type: .plainText)
+        let cc = ContentControl(sdt: sdt106, content: "")
+        // Note: inline SDT lookup currently uses Paragraph.flattenedDisplayText
+        // which walks paragraph.contentControls. We construct a minimal scenario
+        // where the anchor text is in a top-level paragraph.
+        para.runs = [Run(text: "inline anchor text")]
+        para.contentControls = [cc]
+
+        doc.body.children = [
+            .paragraph(para),
+            .paragraph(Paragraph(text: "trailer")),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "inserted"),
+            at: .afterText("inline anchor text", instance: 1)
+        )
+
+        XCTAssertEqual(doc.body.children.count, 3)
+        guard case .paragraph(let p) = doc.body.children[1] else {
+            XCTFail("Expected inserted at idx 1; got \(doc.body.children[1])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "inserted")
+    }
+
+    /// Pre-existing: anchor not found anywhere → throws textNotFound.
+    func testAfterTextNotFoundStillThrows() {
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(Paragraph(text: "haystack"))]
+
+        XCTAssertThrowsError(try doc.insertParagraph(
+            Paragraph(text: "x"),
+            at: .afterText("needle-nope", instance: 1)
+        )) { error in
+            if let we = error as? InsertLocationError,
+               case let .textNotFound(searchText: s, instance: _) = we {
+                XCTAssertEqual(s, "needle-nope")
+            } else {
+                XCTFail("Expected InsertLocationError.textNotFound; got \(error)")
+            }
+        }
+    }
+}

--- a/Tests/OOXMLSwiftTests/Issue68TextAnchorTraversalTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue68TextAnchorTraversalTests.swift
@@ -242,6 +242,69 @@ final class Issue68TextAnchorTraversalTests: XCTestCase {
         XCTAssertEqual(p.runs.first?.text, "inserted")
     }
 
+    // MARK: - Verify-68 P3 fixes
+
+    /// Counting rule pin (Verify-68 Logic P2): a single table containing the
+    /// needle in MULTIPLE cells still counts as ONE `nthInstance`. This locks
+    /// in the design choice (1 BodyChild = 1 instance) so future refactors
+    /// can't silently switch to "1 cell paragraph = 1 instance".
+    func testAfterTextOneTableWithMultipleCellsContainingNeedleIsOneInstance() throws {
+        var doc = WordDocument()
+        let cellA = TableCell(paragraphs: [Paragraph(text: "needle in cell A")])
+        let cellB = TableCell(paragraphs: [Paragraph(text: "needle in cell B")])
+        let cellC = TableCell(paragraphs: [Paragraph(text: "needle in cell C")])
+        let row = TableRow(cells: [cellA, cellB, cellC])
+        let table = Table(rows: [row])
+
+        doc.body.children = [
+            .table(table),                                    // instance 1 (single table, 3 cells)
+            .paragraph(Paragraph(text: "needle outside table")), // instance 2
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "after-instance-2"),
+            at: .afterText("needle", instance: 2)
+        )
+
+        // 2nd instance is the trailing paragraph at original idx 1 → insert at idx 2.
+        XCTAssertEqual(doc.body.children.count, 3)
+        guard case .paragraph(let p) = doc.body.children[2] else {
+            XCTFail("Expected paragraph at idx 2; got \(doc.body.children[2])")
+            return
+        }
+        XCTAssertEqual(p.runs.first?.text, "after-instance-2")
+
+        // Sanity: instance 3 must NOT exist (the 3 cells of the table count as 1).
+        XCTAssertThrowsError(try doc.insertParagraph(
+            Paragraph(text: "x"),
+            at: .afterText("needle", instance: 3)
+        ))
+    }
+
+    /// Empty needle MUST NOT match anything (Verify-68 Logic P3 / DA P2).
+    /// Pre-fix `String.contains("")` returns true, silently inserting at idx 1
+    /// (after the first BodyChild). Post-fix: explicit guard returns nil →
+    /// `textNotFound` thrown.
+    func testAfterTextEmptyNeedleThrowsNotFound() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "hello")),
+            .paragraph(Paragraph(text: "world")),
+        ]
+
+        XCTAssertThrowsError(try doc.insertParagraph(
+            Paragraph(text: "x"),
+            at: .afterText("", instance: 1)
+        )) { error in
+            if let we = error as? InsertLocationError,
+               case let .textNotFound(searchText: s, instance: _) = we {
+                XCTAssertEqual(s, "")
+            } else {
+                XCTFail("Expected InsertLocationError.textNotFound; got \(error)")
+            }
+        }
+    }
+
     /// Pre-existing: anchor not found anywhere → throws textNotFound.
     func testAfterTextNotFoundStillThrows() {
         var doc = WordDocument()


### PR DESCRIPTION
Refs PsychQuant/che-word-mcp#68

## Summary

`InsertLocation.findBodyChildContainingText` (used by `.afterText` / `.beforeText` resolution in `insertParagraph`) previously only iterated `.paragraph` BodyChild cases. Anchor text inside a table cell or block-level `<w:sdt>` was silently skipped → `textNotFound` thrown even though the text was present. Real-world thesis docs (figure/table captions inside table cells) became unanchorable.

Fix recurses into `.table` (rows[].cells[].paragraphs + nestedTables) and `.contentControl(_, children:)` via two new private static helpers (`bodyChildContainsText`, `tableContainsText`). Counting rule preserved (1 top-level BodyChild = 1 `nthInstance` count). Returned idx remains TOP-LEVEL `body.children` index so insert lands at body level adjacent to the containing table/SDT (use `.intoTableCell` for inside-cell inserts).

## Verification

3-AI focused team (Logic + Regression + Devil's Advocate). 0 P0; 1 out-of-scope P1 (pre-existing parser SDT depth, documented as follow-up); 4 in-scope findings fixed in `90dbdd6` (empty-needle guard + multi-cell counting pin test + insert-position docstring + CHANGELOG v0.20.6 entry); 2 out-of-scope P3 (header/footer walks + vendor extension content) documented.

Verify report: https://github.com/PsychQuant/che-word-mcp/issues/68#issuecomment-4333582086

Suite: `696 → 706` (+10 sub-tests, 0 fail / 1 skip).

## Checklist

- [x] Diagnose ✓ (https://github.com/PsychQuant/che-word-mcp/issues/68#issuecomment-4333486883)
- [x] Implement (2 commits — `706d375` core + `90dbdd6` verify polish)
- [x] Verify ✓ (3-AI team, 0 in-scope blocking)
- [x] CHANGELOG v0.20.6 entry
- [ ] **Pending: human review of this PR + merge**
- [ ] **Pending: tag v0.20.6 + GH release** (so che-word-mcp can dep-bump)
- [ ] **Pending: Phase 2 (che-word-mcp dep bump PR + integration test)** after lib release

## Out-of-scope (documented in CHANGELOG)

1. Parser-side SDT depth limit (DA P1 pre-existing — `MAX_SDT_NEST_DEPTH` mirroring `MAX_TABLE_NEST_DEPTH = 5`)
2. Header / footer / footnote / endnote anchor lookup (separate part-container `bodyChildren` walks)
3. Vendor extension content visibility (`.rawBlockElement`)

---
🤖 Generated by `/idd-all` Phase 1 (cross-repo flow). After merge + tag v0.20.6 + release, Phase 2 (che-word-mcp dep bump PR) will resume.
