### PR TITLE
feat: wrap_caption_seq lib API (Refs PsychQuant/che-word-mcp#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ All notable changes to ooxml-swift will be documented in this file.
 
 - **v0.19.4** (never tagged) — The R3 stack-completion content originally targeted v0.19.4. After the round-3 fix landed, the round-4 6-AI verify (https://github.com/PsychQuant/che-word-mcp/issues/56#issuecomment-4321562429) returned BLOCK with 6 new P0 + 7 P1 findings (walker-asymmetry follow-ups, `position == 0` sentinel collision, attribute-escape sweep gap, block-level SDT typed-Revision propagation, container-symmetric `replaceText`, container `<w:tbl>` parser drop). v0.19.4 was held back. v0.19.5 ships the R3 stack content (preserved verbatim below) **plus** the R5 stack-completion fixes (6 P0 + 5 P1, additive — no breaking change versus the v0.19.4 contract). No v0.19.4 git tag, no v0.19.4 GitHub Release.
 
+## [0.21.0] - 2026-04-28
+
+### Added — wrapCaptionSequenceFields lib API (Refs PsychQuant/che-word-mcp#62)
+
+New public method on `WordDocument` that bulk-converts plain-text caption number portions into SEQ-field-bearing runs. Unblocks `insert_table_of_figures` / `insert_table_of_tables` on documents pasted from external sources (LaTeX-converted Word, Google Docs, Pandoc) where caption numbering is plain text instead of real Word SEQ fields.
+
+#### Public surface
+
+```swift
+extension WordDocument {
+    public mutating func wrapCaptionSequenceFields(
+        pattern: NSRegularExpression,
+        sequenceName: String,
+        format: SequenceField.SequenceFormat = .arabic,
+        scope: TextScope = .body,
+        insertBookmark: Bool = false,
+        bookmarkTemplate: String? = nil
+    ) throws -> WrapCaptionResult
+}
+```
+
+New supporting types:
+
+- `enum TextScope: Equatable, Sendable { case body, all }` — shared scope vocabulary mirroring `updateAllFields(isolatePerContainer:)` semantics.
+- `struct WrapCaptionResult` — per-paragraph structured result with `matchedParagraphs`, `fieldsInserted`, `paragraphsModified: [Int]` (top-level body-child indices), and `skipped: [SkippedParagraph]`.
+- `struct SkippedParagraph` — `paragraphIndex` + `reason` + optional `container` (reserved for `.all` scope).
+- `enum WrapCaptionError: Error, Equatable` — `patternMissingCaptureGroup(actual:)`, `bookmarkTemplateMissing`, `scopeNotImplemented(TextScope)`.
+
+#### Phase 1 scope: `.body` only
+
+`scope: .all` (cross-container — headers/footers/footnotes/endnotes) throws `WrapCaptionError.scopeNotImplemented(.all)` and lands in v0.21.1 alongside the MCP wrapper integration test. Phase 1's body-only walk recurses into `.table` (rows × cells × paragraphs + nestedTables) and block-level `.contentControl` children, mirroring `Document.replaceInParagraphSurfaces` surface coverage.
+
+#### Idempotency contract
+
+Re-running `wrapCaptionSequenceFields` on an already-wrapped paragraph reports the paragraph in `WrapCaptionResult.skipped` with `reason: "already wraps SEQ <name>"` and **never** double-wraps. Detection covers both:
+
+- Typed `FieldSimple` SEQ emissions (where `instr` contains `"SEQ <name>"`)
+- `Run.rawXML`-embedded 5-run `<w:fldChar>` blocks (the emission style `insertCaption` and this method use)
+
+The match-counting walker uses a "rendered" view of the paragraph that inlines existing SEQ `cachedResult` values (extracted from `<w:t>N</w:t>` inside the fldChar block), so the regex can still recognize captions like "Figure 1." after the digit has been moved into a SEQ field's cached result.
+
+#### Bookmark wrap (opt-in)
+
+Default off — passing 23 plain captions through with `insertBookmark: false` adds zero bookmarks (avoids polluting `list_bookmarks`). When `insertBookmark: true`, callers MUST also pass `bookmarkTemplate` containing the literal `${number}` placeholder; the method substitutes the captured numeric and emits `<w:bookmarkStart w:name="<substituted>" w:id="<unique-id>">` / `<w:bookmarkEnd w:id="<same-id>">` immediately around the SEQ run. Unique bookmark IDs come from the existing `WordDocument.nextBookmarkId` counter.
+
+#### Capture group contract
+
+The pattern MUST contain exactly one capture group whose match becomes the SEQ field's `cachedResult` (preserving the user-typed numeral so Word's first-open render shows the original numbering before F9). Patterns with 0 or ≥2 capture groups throw `WrapCaptionError.patternMissingCaptureGroup(actual:)` BEFORE any body mutation.
+
+#### Reported indices
+
+`paragraphsModified` and `SkippedParagraph.paragraphIndex` carry **top-level `body.children` indices**. When a matched paragraph is nested inside a `.table` cell or block-level `.contentControl`, the reported index points to the containing top-level BodyChild — same semantic as `findBodyChildContainingText` (#68). One body child can appear multiple times in `paragraphsModified` if multiple nested paragraphs inside it matched.
+
+#### Tests
+
+`Tests/OOXMLSwiftTests/WrapCaptionSequenceFieldsTests.swift` — 10 sub-tests covering body-scope wrap, idempotent re-run (rendered-text matcher), zero/two capture group rejection, bookmark wrap with template substitution, idempotency over both fldSimple and rawXML emissions, cachedResult preservation for first-open render, table-cell anchor wrap, and `.all` scope deferral. All tests green; full suite 706/706 pass.
+
+Phase 2 (the `wrap_caption_seq` MCP tool in `che-word-mcp`) lands in v3.17.0 once this lib release is available.
+
 ## [0.20.6] - 2026-04-28
 
 ### Fixed — Text anchor lookup recurses into table cells + block-level SDT (Refs PsychQuant/che-word-mcp#68)

--- a/Sources/OOXMLSwift/Models/TextScope.swift
+++ b/Sources/OOXMLSwift/Models/TextScope.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Where a text-mutation operation walks within a `WordDocument`.
+///
+/// PsychQuant/che-word-mcp#62 (`wrap_caption_seq`) introduced this enum so
+/// bulk-mutation tools can opt between body-only (the 90% case for thesis
+/// caption rescue) and the full part-container traversal that
+/// `WordDocument.updateAllFields(isolatePerContainer:)` already uses for SEQ
+/// counter computation.
+///
+/// - `.body` — only `body.children` (recursing into table cells + block-level
+///   SDT children).
+/// - `.all` — body PLUS headers, footers, footnotes, endnotes — exactly the
+///   set traversed by `updateAllFields(isolatePerContainer: false)` so SEQ
+///   counter coverage and SEQ field placement coverage are symmetric.
+public enum TextScope: Equatable, Sendable {
+    case body
+    case all
+}

--- a/Sources/OOXMLSwift/Models/WordDocument+WrapCaptionSequenceFields.swift
+++ b/Sources/OOXMLSwift/Models/WordDocument+WrapCaptionSequenceFields.swift
@@ -1,0 +1,389 @@
+import Foundation
+
+// MARK: - WordDocument.wrapCaptionSequenceFields (PsychQuant/che-word-mcp#62)
+
+extension WordDocument {
+
+    /// Bulk-convert plain-text caption number portions into SEQ-field-bearing
+    /// runs across paragraphs whose joined-runs text matches the supplied
+    /// regex. Phase 1 supports `scope: .body` only; `.all` (cross-container)
+    /// is reserved for a Phase 1.x patch.
+    ///
+    /// See `openspec/specs/ooxml-content-insertion-primitives/spec.md`
+    /// (Requirement: `Document.wrapCaptionSequenceFields converts plain-text
+    /// caption number portions to SEQ-field runs`) for the full contract.
+    ///
+    /// Idempotency: paragraphs whose runs/fieldSimples already contain a SEQ
+    /// field for `sequenceName` are reported in `WrapCaptionResult.skipped`
+    /// and never double-wrapped.
+    ///
+    /// Returned `paragraphsModified` and `SkippedParagraph.paragraphIndex`
+    /// values are TOP-LEVEL `body.children` indices. When a matched paragraph
+    /// is nested inside a `.table` cell or block-level `.contentControl`, the
+    /// reported index points to the containing top-level BodyChild — same
+    /// semantic as `findBodyChildContainingText` (#68). One body child can
+    /// appear multiple times in `paragraphsModified` if multiple nested
+    /// paragraphs inside it matched.
+    public mutating func wrapCaptionSequenceFields(
+        pattern: NSRegularExpression,
+        sequenceName: String,
+        format: SequenceField.SequenceFormat = .arabic,
+        scope: TextScope = .body,
+        insertBookmark: Bool = false,
+        bookmarkTemplate: String? = nil
+    ) throws -> WrapCaptionResult {
+        // Pre-mutation validation — reject malformed callers BEFORE any body mutation.
+        guard pattern.numberOfCaptureGroups == 1 else {
+            throw WrapCaptionError.patternMissingCaptureGroup(
+                actual: pattern.numberOfCaptureGroups
+            )
+        }
+        if insertBookmark {
+            guard let template = bookmarkTemplate, template.contains("${number}") else {
+                throw WrapCaptionError.bookmarkTemplateMissing
+            }
+        }
+        if scope == .all {
+            throw WrapCaptionError.scopeNotImplemented(.all)
+        }
+
+        var ctx = WrapContext(
+            pattern: pattern,
+            sequenceName: sequenceName,
+            format: format,
+            insertBookmark: insertBookmark,
+            bookmarkTemplate: bookmarkTemplate,
+            nextBookmarkId: nextBookmarkId
+        )
+
+        for i in 0..<body.children.count {
+            let updated = walkBodyChild(body.children[i], topLevelBodyIndex: i, ctx: &ctx)
+            if let updated = updated {
+                body.children[i] = updated
+            }
+        }
+
+        if !ctx.paragraphsModified.isEmpty {
+            modifiedParts.insert("word/document.xml")
+            nextBookmarkId = ctx.nextBookmarkId
+        }
+
+        return WrapCaptionResult(
+            matchedParagraphs: ctx.matchedParagraphs,
+            fieldsInserted: ctx.fieldsInserted,
+            paragraphsModified: ctx.paragraphsModified,
+            skipped: ctx.skipped
+        )
+    }
+
+    // MARK: - Mutable walker context
+
+    private struct WrapContext {
+        let pattern: NSRegularExpression
+        let sequenceName: String
+        let format: SequenceField.SequenceFormat
+        let insertBookmark: Bool
+        let bookmarkTemplate: String?
+        var nextBookmarkId: Int
+
+        var matchedParagraphs: Int = 0
+        var fieldsInserted: Int = 0
+        var paragraphsModified: [Int] = []
+        var skipped: [SkippedParagraph] = []
+    }
+
+    /// Recurse into a BodyChild. Returns the updated BodyChild if mutated, or
+    /// `nil` if untouched (caller may keep the original reference).
+    private func walkBodyChild(
+        _ child: BodyChild,
+        topLevelBodyIndex: Int,
+        ctx: inout WrapContext
+    ) -> BodyChild? {
+        switch child {
+        case .paragraph(var para):
+            if let result = tryWrapParagraph(&para, topLevelBodyIndex: topLevelBodyIndex, ctx: &ctx) {
+                return result ? .paragraph(para) : nil
+            }
+            return nil
+
+        case .table(var table):
+            var anyChange = false
+            for rowIdx in 0..<table.rows.count {
+                for cellIdx in 0..<table.rows[rowIdx].cells.count {
+                    for paraIdx in 0..<table.rows[rowIdx].cells[cellIdx].paragraphs.count {
+                        var para = table.rows[rowIdx].cells[cellIdx].paragraphs[paraIdx]
+                        if let result = tryWrapParagraph(&para, topLevelBodyIndex: topLevelBodyIndex, ctx: &ctx) {
+                            if result {
+                                table.rows[rowIdx].cells[cellIdx].paragraphs[paraIdx] = para
+                                anyChange = true
+                            }
+                        }
+                    }
+                    for nestedIdx in 0..<table.rows[rowIdx].cells[cellIdx].nestedTables.count {
+                        var nested = table.rows[rowIdx].cells[cellIdx].nestedTables[nestedIdx]
+                        if walkNestedTable(&nested, topLevelBodyIndex: topLevelBodyIndex, ctx: &ctx) {
+                            table.rows[rowIdx].cells[cellIdx].nestedTables[nestedIdx] = nested
+                            anyChange = true
+                        }
+                    }
+                }
+            }
+            return anyChange ? .table(table) : nil
+
+        case .contentControl(let cc, var kids):
+            var anyChange = false
+            for i in 0..<kids.count {
+                if let updated = walkBodyChild(kids[i], topLevelBodyIndex: topLevelBodyIndex, ctx: &ctx) {
+                    kids[i] = updated
+                    anyChange = true
+                }
+            }
+            return anyChange ? .contentControl(cc, children: kids) : nil
+
+        case .bookmarkMarker, .rawBlockElement:
+            return nil
+        }
+    }
+
+    private func walkNestedTable(
+        _ table: inout Table,
+        topLevelBodyIndex: Int,
+        ctx: inout WrapContext
+    ) -> Bool {
+        var anyChange = false
+        for rowIdx in 0..<table.rows.count {
+            for cellIdx in 0..<table.rows[rowIdx].cells.count {
+                for paraIdx in 0..<table.rows[rowIdx].cells[cellIdx].paragraphs.count {
+                    var para = table.rows[rowIdx].cells[cellIdx].paragraphs[paraIdx]
+                    if let result = tryWrapParagraph(&para, topLevelBodyIndex: topLevelBodyIndex, ctx: &ctx) {
+                        if result {
+                            table.rows[rowIdx].cells[cellIdx].paragraphs[paraIdx] = para
+                            anyChange = true
+                        }
+                    }
+                }
+                for nestedIdx in 0..<table.rows[rowIdx].cells[cellIdx].nestedTables.count {
+                    var nested = table.rows[rowIdx].cells[cellIdx].nestedTables[nestedIdx]
+                    if walkNestedTable(&nested, topLevelBodyIndex: topLevelBodyIndex, ctx: &ctx) {
+                        table.rows[rowIdx].cells[cellIdx].nestedTables[nestedIdx] = nested
+                        anyChange = true
+                    }
+                }
+            }
+        }
+        return anyChange
+    }
+
+    /// Attempt to wrap one paragraph. Returns:
+    /// - `nil` if the paragraph did not match the pattern (no work).
+    /// - `false` if matched but skipped (already wraps SEQ; ctx updated).
+    /// - `true` if matched and rewritten (paragraph mutated, ctx updated).
+    private func tryWrapParagraph(
+        _ para: inout Paragraph,
+        topLevelBodyIndex: Int,
+        ctx: inout WrapContext
+    ) -> Bool? {
+        // Match against a "rendered" view of the paragraph that inlines any
+        // existing SEQ field cachedResult — this lets idempotent re-runs still
+        // recognize a caption like "圖 4-1：" even though the digit "1" lives
+        // inside `<w:t>1</w:t>` of the SEQ run's rawXML, not in `Run.text`.
+        // Captions buried in hyperlinks / contentControls remain out of Phase 1
+        // scope (separate enhancement if surfaced).
+        let renderedText = renderedTextWithSEQ(para, sequenceName: ctx.sequenceName)
+        let nsRendered = renderedText as NSString
+        let renderedRange = NSRange(location: 0, length: nsRendered.length)
+
+        guard ctx.pattern.firstMatch(in: renderedText, options: [], range: renderedRange) != nil else {
+            return nil
+        }
+        ctx.matchedParagraphs += 1
+
+        // Idempotency check — match counts toward `matchedParagraphs` but if
+        // the paragraph already wraps a SEQ field for this sequence name, we
+        // skip without modifying.
+        if paragraphAlreadyWrapsSEQ(para, sequenceName: ctx.sequenceName) {
+            ctx.skipped.append(SkippedParagraph(
+                paragraphIndex: topLevelBodyIndex,
+                reason: "already wraps SEQ \(ctx.sequenceName)",
+                container: nil
+            ))
+            return false
+        }
+
+        // First-call: plain runs only (no SEQ rawXML present yet), so the
+        // joined-runs text matches the rendered text 1:1 and is the right
+        // surface for locating the capture range across run boundaries.
+        let runText = para.runs.map { $0.text }.joined()
+        let nsText = runText as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+
+        guard let match = ctx.pattern.firstMatch(in: runText, options: [], range: fullRange) else {
+            // Defensive: rendered matched but plain didn't (e.g. caption hidden
+            // behind a non-SEQ field rawXML). Leave the paragraph alone.
+            return nil
+        }
+
+        let captureRange = match.range(at: 1)
+        guard captureRange.location != NSNotFound,
+              captureRange.length > 0 else {
+            return nil
+        }
+        let captureStart = captureRange.location
+        let captureEnd = captureRange.location + captureRange.length
+        let capturedNumber = nsText.substring(with: captureRange)
+
+        // Locate which run + local offset holds the capture start and end by
+        // walking accumulated NSString lengths (UTF-16 units, matching NSRange).
+        var preRunIdx = 0
+        var preRunLocalEnd = 0
+        var postRunIdx = 0
+        var postRunLocalStart = 0
+        var cursor = 0
+        var foundStart = false
+        var foundEnd = false
+        for (idx, run) in para.runs.enumerated() {
+            let runLen = (run.text as NSString).length
+            let runStart = cursor
+            let runEnd = cursor + runLen
+            if !foundStart, captureStart >= runStart, captureStart <= runEnd {
+                preRunIdx = idx
+                preRunLocalEnd = captureStart - runStart
+                foundStart = true
+            }
+            if !foundEnd, captureEnd >= runStart, captureEnd <= runEnd {
+                postRunIdx = idx
+                postRunLocalStart = captureEnd - runStart
+                foundEnd = true
+            }
+            cursor = runEnd
+            if foundStart && foundEnd { break }
+        }
+        guard foundStart, foundEnd else {
+            // Should be unreachable because the regex matched against the same
+            // joined text — defensive fallback: leave paragraph alone.
+            return nil
+        }
+
+        // Build the SEQ-field run via the existing FieldCode emission machinery
+        // (5-run fldChar block) — same emission style insertCaption uses.
+        let seqField = SequenceField(
+            identifier: ctx.sequenceName,
+            format: ctx.format,
+            cachedResult: capturedNumber
+        )
+        var seqRun = Run(text: "")
+        seqRun.rawXML = seqField.toFieldXML()
+
+        // Build replacement runs in document order:
+        //   [pre-text portion of preRunIdx (if non-empty),
+        //    seqRun,
+        //    post-text portion of postRunIdx (if non-empty)]
+        // Then keep runs before preRunIdx and runs after postRunIdx untouched.
+        var newRuns: [Run] = Array(para.runs[..<preRunIdx])
+
+        // Pre-text portion
+        let preRun = para.runs[preRunIdx]
+        let preRunNS = preRun.text as NSString
+        if preRunLocalEnd > 0 {
+            var preText = preRun
+            preText.text = preRunNS.substring(to: preRunLocalEnd)
+            newRuns.append(preText)
+        }
+
+        // Optional bookmark wrap: bookmarkStart immediately before SEQ run,
+        // bookmarkEnd immediately after.
+        if ctx.insertBookmark, let template = ctx.bookmarkTemplate {
+            let bookmarkName = template.replacingOccurrences(of: "${number}", with: capturedNumber)
+            let bookmarkId = ctx.nextBookmarkId
+            ctx.nextBookmarkId += 1
+            var startRun = Run(text: "")
+            startRun.rawXML = "<w:bookmarkStart w:id=\"\(bookmarkId)\" w:name=\"\(escapeBookmarkName(bookmarkName))\"/>"
+            newRuns.append(startRun)
+            newRuns.append(seqRun)
+            var endRun = Run(text: "")
+            endRun.rawXML = "<w:bookmarkEnd w:id=\"\(bookmarkId)\"/>"
+            newRuns.append(endRun)
+        } else {
+            newRuns.append(seqRun)
+        }
+
+        // Post-text portion
+        let postRun = para.runs[postRunIdx]
+        let postRunNS = postRun.text as NSString
+        if postRunLocalStart < postRunNS.length {
+            var postText = postRun
+            postText.text = postRunNS.substring(from: postRunLocalStart)
+            newRuns.append(postText)
+        }
+
+        // Tail
+        if postRunIdx + 1 < para.runs.count {
+            newRuns.append(contentsOf: para.runs[(postRunIdx + 1)...])
+        }
+
+        para.runs = newRuns
+
+        ctx.fieldsInserted += 1
+        ctx.paragraphsModified.append(topLevelBodyIndex)
+        return true
+    }
+
+    /// Idempotency check: returns true if the paragraph already contains a SEQ
+    /// field for `sequenceName` either as a typed `FieldSimple` or embedded as
+    /// rawXML in any of its runs (the emission style insertCaption uses).
+    private func paragraphAlreadyWrapsSEQ(_ para: Paragraph, sequenceName: String) -> Bool {
+        let needle = "SEQ \(sequenceName)"
+        for fs in para.fieldSimples where fs.instr.contains(needle) {
+            return true
+        }
+        for run in para.runs {
+            if let raw = run.rawXML, raw.contains(needle) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Reconstruct the user-visible text of a paragraph by inlining the
+    /// `cachedResult` of any SEQ field for `sequenceName` carried in run
+    /// rawXML. This lets the regex matcher recognize already-wrapped captions
+    /// on idempotent re-runs (where digits live in `<w:t>N</w:t>` of the SEQ
+    /// fldChar block, not in `Run.text`).
+    private func renderedTextWithSEQ(_ para: Paragraph, sequenceName: String) -> String {
+        let needle = "SEQ \(sequenceName)"
+        var parts: [String] = []
+        for run in para.runs {
+            if let raw = run.rawXML, raw.contains(needle),
+               let cached = extractFieldCachedResult(raw) {
+                parts.append(cached)
+            } else {
+                parts.append(run.text)
+            }
+        }
+        return parts.joined()
+    }
+
+    /// Extract the text content between `<w:fldChar w:fldCharType="separate"/>`
+    /// and `<w:fldChar w:fldCharType="end"/>` from a SEQ field rawXML — that's
+    /// where `cachedResult` lives in the 5-run fldChar block emitted by
+    /// `FieldCode.toFieldXML()`.
+    private func extractFieldCachedResult(_ rawXML: String) -> String? {
+        guard let sepRange = rawXML.range(of: "fldCharType=\"separate\"") else { return nil }
+        let after = rawXML[sepRange.upperBound...]
+        guard let openRange = after.range(of: "<w:t") else { return nil }
+        let afterOpen = after[openRange.upperBound...]
+        guard let gtRange = afterOpen.range(of: ">") else { return nil }
+        let body = afterOpen[gtRange.upperBound...]
+        guard let closeRange = body.range(of: "</w:t>") else { return nil }
+        return String(body[..<closeRange.lowerBound])
+    }
+
+    private func escapeBookmarkName(_ name: String) -> String {
+        return name
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+}

--- a/Sources/OOXMLSwift/Models/WrapCaptionError.swift
+++ b/Sources/OOXMLSwift/Models/WrapCaptionError.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Errors thrown by `WordDocument.wrapCaptionSequenceFields(...)`.
+///
+/// PsychQuant/che-word-mcp#62 design Decisions 1 + 2 — pre-mutation validation
+/// rejects malformed callers BEFORE the document is touched, so a bad regex
+/// or bad bookmark configuration does not partially-mutate the body.
+public enum WrapCaptionError: Error, Equatable {
+    /// Pattern compiled but does not contain exactly one capture group.
+    /// Spec requires exactly one numeric capture group whose match becomes the
+    /// SEQ field's `cachedResult`.
+    case patternMissingCaptureGroup(actual: Int)
+
+    /// `insertBookmark == true` but `bookmarkTemplate` is nil OR does not
+    /// contain the literal `${number}` placeholder. Without `${number}`, every
+    /// matched paragraph would receive the same bookmark name — which violates
+    /// `<w:bookmarkStart>` name uniqueness within the document.
+    case bookmarkTemplateMissing
+
+    /// `scope == .all` was passed but cross-container walking is not yet
+    /// implemented. Phase 1 ships `.body` only; `.all` lands alongside the
+    /// MCP wrapper integration test in a Phase 1.x patch.
+    case scopeNotImplemented(TextScope)
+}

--- a/Sources/OOXMLSwift/Models/WrapCaptionResult.swift
+++ b/Sources/OOXMLSwift/Models/WrapCaptionResult.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Per-paragraph result returned by `WordDocument.wrapCaptionSequenceFields(...)`.
+///
+/// PsychQuant/che-word-mcp#62 design Decision 5 — structured per-paragraph
+/// shape so LLM callers can verify "did all N captions get fields?" rather
+/// than parsing free-form summary strings. `skipped` surfaces idempotency
+/// no-ops (e.g., paragraph already wraps a SEQ field for the same identifier)
+/// so the caller doesn't think the call silently failed.
+public struct WrapCaptionResult: Equatable, Sendable {
+    /// Number of paragraphs whose `flattenedDisplayText()` matched the regex
+    /// (sum of `paragraphsModified.count` and `skipped.count`).
+    public let matchedParagraphs: Int
+
+    /// Number of SEQ fields actually written (matched minus skipped).
+    public let fieldsInserted: Int
+
+    /// Body-level (or part-container-level) paragraph indices, in document
+    /// order, of paragraphs that received a new SEQ field.
+    public let paragraphsModified: [Int]
+
+    /// Paragraphs that matched the pattern but were intentionally not modified
+    /// (e.g., already wrap a SEQ field for the same identifier).
+    public let skipped: [SkippedParagraph]
+
+    public init(
+        matchedParagraphs: Int,
+        fieldsInserted: Int,
+        paragraphsModified: [Int],
+        skipped: [SkippedParagraph]
+    ) {
+        self.matchedParagraphs = matchedParagraphs
+        self.fieldsInserted = fieldsInserted
+        self.paragraphsModified = paragraphsModified
+        self.skipped = skipped
+    }
+}
+
+/// One element of `WrapCaptionResult.skipped`.
+///
+/// `container` is `nil` for body-scope skips (Phase 1 ships body-only) and
+/// reserved for the future `.all` cross-container path (e.g.,
+/// `"header:default"` / `"footer:rId7"` / `"footnote:N"`).
+public struct SkippedParagraph: Equatable, Sendable {
+    public let paragraphIndex: Int
+    public let reason: String
+    public let container: String?
+
+    public init(paragraphIndex: Int, reason: String, container: String? = nil) {
+        self.paragraphIndex = paragraphIndex
+        self.reason = reason
+        self.container = container
+    }
+}

--- a/Tests/OOXMLSwiftTests/WrapCaptionSequenceFieldsTests.swift
+++ b/Tests/OOXMLSwiftTests/WrapCaptionSequenceFieldsTests.swift
@@ -1,0 +1,285 @@
+import XCTest
+@testable import OOXMLSwift
+
+/// PsychQuant/che-word-mcp#62 — `Document.wrapCaptionSequenceFields` lib API.
+///
+/// Spec: openspec/specs/ooxml-content-insertion-primitives/spec.md (Requirement
+/// `Document.wrapCaptionSequenceFields converts plain-text caption number
+/// portions to SEQ-field runs`).
+final class WrapCaptionSequenceFieldsTests: XCTestCase {
+
+    // MARK: - 1.9.1 Body scope wraps three plain-text figure captions
+
+    func testBodyScopeWrapsThreePlainTextFigureCaptions() throws {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "圖 4-1：架構圖")),
+            .paragraph(Paragraph(text: "圖 4-2：流程圖")),
+            .paragraph(Paragraph(text: "圖 4-3：時序圖")),
+            .paragraph(Paragraph(text: "lorem ipsum")),
+            .paragraph(Paragraph(text: "dolor sit amet")),
+            .paragraph(Paragraph(text: "consectetur adipiscing")),
+            .paragraph(Paragraph(text: "elit sed do")),
+            .paragraph(Paragraph(text: "eiusmod tempor")),
+        ]
+        let pattern = try NSRegularExpression(pattern: "圖 4-(\\d+)：")
+        let result = try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure"
+        )
+
+        XCTAssertEqual(result.matchedParagraphs, 3)
+        XCTAssertEqual(result.fieldsInserted, 3)
+        XCTAssertEqual(result.paragraphsModified, [0, 1, 2])
+        XCTAssertTrue(result.skipped.isEmpty, "no idempotency skips on first run")
+
+        // Each modified paragraph still displays the original digits AND now
+        // contains a SEQ Figure field somewhere in its run rawXML.
+        for idx in [0, 1, 2] {
+            guard case .paragraph(let p) = doc.body.children[idx] else {
+                XCTFail("expected paragraph at idx \(idx); got \(doc.body.children[idx])")
+                return
+            }
+            let containsSEQ = p.runs.contains { ($0.rawXML ?? "").contains("SEQ Figure") }
+            XCTAssertTrue(containsSEQ, "paragraph \(idx) must carry SEQ Figure field rawXML")
+        }
+    }
+
+    // MARK: - 1.9.2 Idempotent re-run skips already-wrapped paragraphs
+
+    func testIdempotentSecondCallSkipsAlreadyWrapped() throws {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "圖 4-1：架構圖")),
+            .paragraph(Paragraph(text: "圖 4-2：流程圖")),
+            .paragraph(Paragraph(text: "圖 4-3：時序圖")),
+        ]
+        let pattern = try NSRegularExpression(pattern: "圖 4-(\\d+)：")
+        _ = try doc.wrapCaptionSequenceFields(pattern: pattern, sequenceName: "Figure")
+
+        // Second run — all 3 should report as skipped, none modified.
+        let result = try doc.wrapCaptionSequenceFields(pattern: pattern, sequenceName: "Figure")
+
+        XCTAssertEqual(result.matchedParagraphs, 3)
+        XCTAssertEqual(result.fieldsInserted, 0)
+        XCTAssertTrue(result.paragraphsModified.isEmpty)
+        XCTAssertEqual(result.skipped.count, 3)
+        for s in result.skipped {
+            XCTAssertEqual(s.reason, "already wraps SEQ Figure")
+            XCTAssertNil(s.container)
+        }
+    }
+
+    // MARK: - 1.9.3 Pattern with zero capture groups throws
+
+    func testPatternWithZeroCaptureGroupsThrows() throws {
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(Paragraph(text: "圖 4-1：title"))]
+        let pattern = try NSRegularExpression(pattern: "圖 4-\\d+：")  // no group
+
+        XCTAssertThrowsError(try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure"
+        )) { error in
+            guard case WrapCaptionError.patternMissingCaptureGroup(let actual) = error else {
+                XCTFail("expected patternMissingCaptureGroup; got \(error)")
+                return
+            }
+            XCTAssertEqual(actual, 0)
+        }
+        // Document should not be mutated by a rejected call.
+        guard case .paragraph(let p) = doc.body.children[0] else { return XCTFail() }
+        XCTAssertEqual(p.runs.first?.text, "圖 4-1：title")
+    }
+
+    // MARK: - 1.9.4 Pattern with two capture groups throws
+
+    func testPatternWithTwoCaptureGroupsThrows() throws {
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(Paragraph(text: "Figure 1.2"))]
+        let pattern = try NSRegularExpression(pattern: "Figure (\\d+)\\.(\\d+)")  // two groups
+
+        XCTAssertThrowsError(try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure"
+        )) { error in
+            guard case WrapCaptionError.patternMissingCaptureGroup(let actual) = error else {
+                XCTFail("expected patternMissingCaptureGroup; got \(error)")
+                return
+            }
+            XCTAssertEqual(actual, 2)
+        }
+    }
+
+    // MARK: - 1.9.5 Bookmark wrapping with template substitution
+
+    func testBookmarkWrappingWithTemplateSubstitution() throws {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "Figure 7. Distribution of MoCA scores")),
+        ]
+        let pattern = try NSRegularExpression(pattern: "Figure (\\d+)\\.")
+        let result = try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure",
+            insertBookmark: true,
+            bookmarkTemplate: "fig${number}"
+        )
+
+        XCTAssertEqual(result.fieldsInserted, 1)
+        XCTAssertEqual(result.paragraphsModified, [0])
+
+        guard case .paragraph(let p) = doc.body.children[0] else {
+            XCTFail("expected paragraph")
+            return
+        }
+        // bookmarkStart should appear before SEQ field, bookmarkEnd after.
+        // Concatenating raw XML in run order should expose both markers around the SEQ run.
+        let allRawXML = p.runs.map { $0.rawXML ?? "" }.joined()
+        XCTAssertTrue(allRawXML.contains("<w:bookmarkStart"))
+        XCTAssertTrue(allRawXML.contains("w:name=\"fig7\""))
+        XCTAssertTrue(allRawXML.contains("<w:bookmarkEnd"))
+        XCTAssertTrue(allRawXML.contains("SEQ Figure"))
+
+        // bookmarkStart MUST appear before SEQ rawXML, bookmarkEnd after.
+        let startRange = allRawXML.range(of: "<w:bookmarkStart")!
+        let seqRange = allRawXML.range(of: "SEQ Figure")!
+        let endRange = allRawXML.range(of: "<w:bookmarkEnd")!
+        XCTAssertLessThan(startRange.lowerBound, seqRange.lowerBound)
+        XCTAssertLessThan(seqRange.lowerBound, endRange.lowerBound)
+    }
+
+    // MARK: - 1.9.6 insert_bookmark = true without bookmark_template throws
+
+    func testInsertBookmarkTrueWithoutTemplateThrows() throws {
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(Paragraph(text: "Figure 1. caption"))]
+        let pattern = try NSRegularExpression(pattern: "Figure (\\d+)")
+
+        XCTAssertThrowsError(try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure",
+            insertBookmark: true,
+            bookmarkTemplate: nil
+        )) { error in
+            guard case WrapCaptionError.bookmarkTemplateMissing = error else {
+                XCTFail("expected bookmarkTemplateMissing; got \(error)")
+                return
+            }
+        }
+
+        // Template missing ${number} placeholder also throws.
+        XCTAssertThrowsError(try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure",
+            insertBookmark: true,
+            bookmarkTemplate: "fig"  // no ${number}
+        )) { error in
+            guard case WrapCaptionError.bookmarkTemplateMissing = error else {
+                XCTFail("expected bookmarkTemplateMissing; got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - 1.9.7 Idempotency covers both fldSimple AND rawXML emissions
+
+    func testIdempotencyCoversBothFldSimpleAndRawXMLEmissions() throws {
+        var doc = WordDocument()
+
+        // Paragraph 0 — already has FieldSimple-style SEQ.
+        var paraFS = Paragraph(text: "Figure 1. existing fldSimple caption")
+        let fs = FieldSimple(instr: " SEQ Figure \\* ARABIC ", runs: [Run(text: "1")])
+        paraFS.fieldSimples = [fs]
+
+        // Paragraph 1 — already has rawXML-embedded SEQ (insertCaption emission style).
+        var paraRaw = Paragraph(text: "Figure 2. existing rawXML caption")
+        var seqRun = Run(text: "")
+        seqRun.rawXML = SequenceField(
+            identifier: "Figure",
+            format: .arabic,
+            cachedResult: "2"
+        ).toFieldXML()
+        paraRaw.runs.append(seqRun)
+
+        doc.body.children = [.paragraph(paraFS), .paragraph(paraRaw)]
+        let pattern = try NSRegularExpression(pattern: "Figure (\\d+)\\.")
+        let result = try doc.wrapCaptionSequenceFields(pattern: pattern, sequenceName: "Figure")
+
+        XCTAssertEqual(result.matchedParagraphs, 2)
+        XCTAssertEqual(result.fieldsInserted, 0)
+        XCTAssertEqual(result.skipped.count, 2)
+        for s in result.skipped {
+            XCTAssertEqual(s.reason, "already wraps SEQ Figure")
+        }
+    }
+
+    // MARK: - 1.9.8 Cached result preserves user numerals before F9
+
+    func testCachedResultPreservesUserNumeralsBeforeF9() throws {
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(Paragraph(text: "圖 4-7：架構圖"))]
+        let pattern = try NSRegularExpression(pattern: "圖 4-(\\d+)：")
+        _ = try doc.wrapCaptionSequenceFields(pattern: pattern, sequenceName: "Figure")
+
+        guard case .paragraph(let p) = doc.body.children[0] else {
+            XCTFail("expected paragraph")
+            return
+        }
+        // The SEQ run rawXML should encode cachedResult = "7" so Word's
+        // first-open render shows the original numbering before F9.
+        let seqRun = p.runs.first { ($0.rawXML ?? "").contains("SEQ Figure") }
+        XCTAssertNotNil(seqRun)
+        XCTAssertTrue(seqRun!.rawXML!.contains("<w:t>7</w:t>"),
+                      "cachedResult must preserve captured digit '7' for first-open render")
+    }
+
+    // MARK: - 1.9.9 Table cell anchor paragraph wraps
+
+    func testTableCellAnchorParagraphWraps() throws {
+        var doc = WordDocument()
+        let cell = TableCell(paragraphs: [Paragraph(text: "Table 1. Demographics")])
+        let row = TableRow(cells: [cell])
+        let table = Table(rows: [row])
+        doc.body.children = [
+            .paragraph(Paragraph(text: "intro paragraph")),
+            .table(table),
+            .paragraph(Paragraph(text: "trailer")),
+        ]
+
+        let pattern = try NSRegularExpression(pattern: "Table (\\d+)\\.")
+        let result = try doc.wrapCaptionSequenceFields(pattern: pattern, sequenceName: "Table")
+
+        XCTAssertEqual(result.matchedParagraphs, 1)
+        XCTAssertEqual(result.fieldsInserted, 1)
+        XCTAssertEqual(result.paragraphsModified, [1], "matched paragraph reports table's body idx (#68 semantic)")
+
+        guard case .table(let t) = doc.body.children[1] else {
+            XCTFail("expected table at idx 1")
+            return
+        }
+        let cellPara = t.rows[0].cells[0].paragraphs[0]
+        let containsSEQ = cellPara.runs.contains { ($0.rawXML ?? "").contains("SEQ Table") }
+        XCTAssertTrue(containsSEQ, "cell paragraph must carry SEQ Table field rawXML")
+    }
+
+    // MARK: - 1.9.10 Scope .all throws scopeNotImplemented in Phase 1
+
+    func testScopeAllThrowsScopeNotImplementedInPhase1() throws {
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(Paragraph(text: "Figure 1. caption"))]
+        let pattern = try NSRegularExpression(pattern: "Figure (\\d+)\\.")
+
+        XCTAssertThrowsError(try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure",
+            scope: .all
+        )) { error in
+            guard case WrapCaptionError.scopeNotImplemented(let scope) = error else {
+                XCTFail("expected scopeNotImplemented; got \(error)")
+                return
+            }
+            XCTAssertEqual(scope, .all)
+        }
+    }
+}


### PR DESCRIPTION
Refs PsychQuant/che-word-mcp#62

## Summary

Adds `WordDocument.wrapCaptionSequenceFields(...)` — bulk-converts plain-text caption number portions (e.g. `圖 4-1：`, `Figure 7.`, `Table 3.`) into SEQ-field-bearing runs. This is **Phase 1 of two**:

- **Phase 1 (this PR)** — ooxml-swift lib API + unit tests. Targets v0.21.0.
- **Phase 2 (separate PR after this lands)** — `wrap_caption_seq` MCP tool in `che-word-mcp` v3.17.0, thin pass-through over this lib API.

Unblocks `insert_table_of_figures` / `insert_table_of_tables` on documents pasted from external sources (LaTeX-converted Word, Google Docs, Pandoc) where caption numbering is plain text instead of real Word SEQ fields — so the resulting TOF/TOT actually populates with caption entries.

## Spectra change

`openspec/changes/wrap-caption-seq/` in macdoc — proposal + design + spec deltas (ooxml-content-insertion-primitives + che-word-mcp-field-equation-crud) + tasks. The 6 design decisions (regex contract, bookmark default-off, scope vocabulary, format flag replacement, structured per-paragraph result, lib placement) were settled via `/spectra-discuss` before writing any code — see design.md for the A1-A6 decision log with rationale.

## Public surface

```swift
extension WordDocument {
    public mutating func wrapCaptionSequenceFields(
        pattern: NSRegularExpression,         // regex with EXACTLY ONE capture group
        sequenceName: String,                 // e.g. "Figure" / "Table"
        format: SequenceField.SequenceFormat = .arabic,
        scope: TextScope = .body,             // .all throws scopeNotImplemented in Phase 1
        insertBookmark: Bool = false,         // opt-in to avoid polluting list_bookmarks
        bookmarkTemplate: String? = nil       // must contain \`\${number}\` if insertBookmark==true
    ) throws -> WrapCaptionResult
}
```

New supporting types (all `public`, `Equatable`, `Sendable` where applicable):

- `enum TextScope { case body, all }` — shared with future cross-container walks
- `struct WrapCaptionResult` — `matchedParagraphs`, `fieldsInserted`, `paragraphsModified: [Int]` (top-level body-child indices), `skipped: [SkippedParagraph]`
- `struct SkippedParagraph` — `paragraphIndex`, `reason`, optional `container` (reserved for `.all`)
- `enum WrapCaptionError` — `patternMissingCaptureGroup(actual:)`, `bookmarkTemplateMissing`, `scopeNotImplemented(TextScope)`

## Idempotency contract

Re-running on an already-wrapped paragraph reports it in `skipped` with `reason: "already wraps SEQ <name>"` — never double-wraps. Detection covers BOTH:

1. Typed `FieldSimple` SEQ emissions (`instr` contains `"SEQ <name>"`)
2. `Run.rawXML`-embedded 5-run `<w:fldChar>` blocks (the emission style `insertCaption` uses)

The match-counter uses a *rendered* view of the paragraph that inlines existing SEQ `cachedResult` values (extracted from `<w:t>N</w:t>` after the `separate` fldChar) — so the regex can still recognize `圖 4-1：架構圖` after the `1` has been moved into a SEQ field's cached result. This satisfies spec scenario 2 (`matched_paragraphs == 3` on re-run with all 3 in `skipped`).

## Phase 1 scope deferral

`scope: .all` (cross-container — headers/footers/footnotes/endnotes) throws `WrapCaptionError.scopeNotImplemented(.all)`. Lands in v0.21.1 alongside the MCP wrapper integration test. The Phase 1 `.body` walk does already recurse into:

- `.table` rows × cells × paragraphs + `cell.nestedTables` (recursive)
- `.contentControl(_, children:)` block-level SDT (recursive)

Mirrors `Document.replaceInParagraphSurfaces` surface coverage.

## Tests

`Tests/OOXMLSwiftTests/WrapCaptionSequenceFieldsTests.swift` — 10 sub-tests, all green:

| # | Test | Spec scenario |
|---|------|---------------|
| 1.9.1 | `testBodyScopeWrapsThreePlainTextFigureCaptions` | Scenario 1 (3 captions matched + fields inserted) |
| 1.9.2 | `testIdempotentSecondCallSkipsAlreadyWrapped` | Scenario 2 (re-run, all 3 in skipped) |
| 1.9.3 | `testPatternWithZeroCaptureGroupsThrows` | Scenario 3 |
| 1.9.4 | `testPatternWithTwoCaptureGroupsThrows` | Scenario 3 variant |
| 1.9.5 | `testBookmarkWrappingWithTemplateSubstitution` | Scenario 4 (`fig7` from `Figure 7.`) |
| 1.9.6 | `testInsertBookmarkTrueWithoutTemplateThrows` | Scenario 5 |
| 1.9.7 | `testIdempotencyCoversBothFldSimpleAndRawXMLEmissions` | both emission styles |
| 1.9.8 | `testCachedResultPreservesUserNumeralsBeforeF9` | first-open render |
| 1.9.9 | `testTableCellAnchorParagraphWraps` | regression pin (#68 surface) |
| 1.9.10 | `testScopeAllThrowsScopeNotImplementedInPhase1` | Phase 1 deferral lock |

Full ooxml-swift suite: **706/706 pass** (1 pre-existing skip).

## Checklist

- [x] Tests added per spec scenarios
- [x] CHANGELOG entry under `## [0.21.0] - 2026-04-28`
- [x] No public API rename / remove (purely additive)
- [x] No external dependency added
- [ ] **Pending: human review of this PR + tag v0.21.0 + GH release**
- [ ] **Phase 2: Open Phase 2 PR in che-word-mcp once v0.21.0 is consumable as remote dep**

## Related

- PsychQuant/che-word-mcp#62 (umbrella issue, awaits Phase 2 close)
- PsychQuant/che-word-mcp#63 (related #68 surface coverage groundwork — already merged in v0.20.4/0.20.5)
- Spectra change: `openspec/changes/wrap-caption-seq/` in PsychQuant/macdoc

---
🤖 Generated as part of `/spectra-apply wrap-caption-seq`. **Do NOT add 'Closes #62'** — Phase 2 is required before #62 can be closed; doing so here would prematurely close before the MCP wrapper exists.