### PR TITLE
Cover SEQ fields in OOXML containers

### DIFF
--- a/Sources/OOXMLSwift/Models/WordDocument+UpdateAllFields.swift
+++ b/Sources/OOXMLSwift/Models/WordDocument+UpdateAllFields.swift
@@ -64,18 +64,13 @@ extension WordDocument {
         // Headings nested inside tables / SDTs do NOT increment. Rationale:
         // thesis workflows put chapter headings at body top level; SDT/table
         // -internal headings are rare and would create false resets.
-        var bodyDirty = false
-        for i in 0..<body.children.count {
-            if walkAndProcessBodyChildForFields(
-                &body.children[i],
-                counters: &counters,
-                lastResetHeadingCount: &lastResetHeadingCount,
-                currentHeadingCount: &currentHeadingCount,
-                isTopLevel: true
-            ) {
-                bodyDirty = true
-            }
-        }
+        let bodyDirty = walkAndProcessBodyChildrenForFields(
+            &body.children,
+            counters: &counters,
+            lastResetHeadingCount: &lastResetHeadingCount,
+            currentHeadingCount: &currentHeadingCount,
+            isTopLevel: true
+        )
 
         // Capture body's final counter state for return (per spec contract).
         // Per-container counter snapshots are NOT in the return value;
@@ -88,14 +83,14 @@ extension WordDocument {
         for i in 0..<headers.count {
             var headerCounters: [String: Int] = isolatePerContainer ? [:] : counters
             var headerLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
-            var headerDirty = false
-            for j in 0..<headers[i].paragraphs.count {
-                var para = headers[i].paragraphs[j]
-                if processParagraph(&para, counters: &headerCounters, lastResetHeadingCount: &headerLastReset, currentHeadingCount: currentHeadingCount) {
-                    headerDirty = true
-                }
-                headers[i].paragraphs[j] = para
-            }
+            var headerHeadingCount = currentHeadingCount
+            let headerDirty = walkAndProcessBodyChildrenForFields(
+                &headers[i].bodyChildren,
+                counters: &headerCounters,
+                lastResetHeadingCount: &headerLastReset,
+                currentHeadingCount: &headerHeadingCount,
+                isTopLevel: false
+            )
             if !isolatePerContainer {
                 counters = headerCounters
                 lastResetHeadingCount = headerLastReset
@@ -108,14 +103,14 @@ extension WordDocument {
         for i in 0..<footers.count {
             var footerCounters: [String: Int] = isolatePerContainer ? [:] : counters
             var footerLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
-            var footerDirty = false
-            for j in 0..<footers[i].paragraphs.count {
-                var para = footers[i].paragraphs[j]
-                if processParagraph(&para, counters: &footerCounters, lastResetHeadingCount: &footerLastReset, currentHeadingCount: currentHeadingCount) {
-                    footerDirty = true
-                }
-                footers[i].paragraphs[j] = para
-            }
+            var footerHeadingCount = currentHeadingCount
+            let footerDirty = walkAndProcessBodyChildrenForFields(
+                &footers[i].bodyChildren,
+                counters: &footerCounters,
+                lastResetHeadingCount: &footerLastReset,
+                currentHeadingCount: &footerHeadingCount,
+                isTopLevel: false
+            )
             if !isolatePerContainer {
                 counters = footerCounters
                 lastResetHeadingCount = footerLastReset
@@ -128,12 +123,15 @@ extension WordDocument {
         var footnotesLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
         var footnotesDirty = false
         for i in 0..<footnotes.footnotes.count {
-            for j in 0..<footnotes.footnotes[i].paragraphs.count {
-                var para = footnotes.footnotes[i].paragraphs[j]
-                if processParagraph(&para, counters: &footnotesCounters, lastResetHeadingCount: &footnotesLastReset, currentHeadingCount: currentHeadingCount) {
-                    footnotesDirty = true
-                }
-                footnotes.footnotes[i].paragraphs[j] = para
+            var footnoteHeadingCount = currentHeadingCount
+            if walkAndProcessBodyChildrenForFields(
+                &footnotes.footnotes[i].bodyChildren,
+                counters: &footnotesCounters,
+                lastResetHeadingCount: &footnotesLastReset,
+                currentHeadingCount: &footnoteHeadingCount,
+                isTopLevel: false
+            ) {
+                footnotesDirty = true
             }
         }
         if !isolatePerContainer {
@@ -146,12 +144,15 @@ extension WordDocument {
         var endnotesLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
         var endnotesDirty = false
         for i in 0..<endnotes.endnotes.count {
-            for j in 0..<endnotes.endnotes[i].paragraphs.count {
-                var para = endnotes.endnotes[i].paragraphs[j]
-                if processParagraph(&para, counters: &endnotesCounters, lastResetHeadingCount: &endnotesLastReset, currentHeadingCount: currentHeadingCount) {
-                    endnotesDirty = true
-                }
-                endnotes.endnotes[i].paragraphs[j] = para
+            var endnoteHeadingCount = currentHeadingCount
+            if walkAndProcessBodyChildrenForFields(
+                &endnotes.endnotes[i].bodyChildren,
+                counters: &endnotesCounters,
+                lastResetHeadingCount: &endnotesLastReset,
+                currentHeadingCount: &endnoteHeadingCount,
+                isTopLevel: false
+            ) {
+                endnotesDirty = true
             }
         }
         if !isolatePerContainer {
@@ -181,6 +182,29 @@ extension WordDocument {
     /// Only direct top-level body paragraphs trigger the heading counter to
     /// avoid container-nested headings causing false SEQ chapter-resets (#94).
     ///
+    /// - Returns: `true` if any descendant paragraph had a SEQ field rewritten.
+    private func walkAndProcessBodyChildrenForFields(
+        _ children: inout [BodyChild],
+        counters: inout [String: Int],
+        lastResetHeadingCount: inout [String: Int],
+        currentHeadingCount: inout [Int: Int],
+        isTopLevel: Bool
+    ) -> Bool {
+        var anyDirty = false
+        for i in 0..<children.count {
+            if walkAndProcessBodyChildForFields(
+                &children[i],
+                counters: &counters,
+                lastResetHeadingCount: &lastResetHeadingCount,
+                currentHeadingCount: &currentHeadingCount,
+                isTopLevel: isTopLevel
+            ) {
+                anyDirty = true
+            }
+        }
+        return anyDirty
+    }
+
     /// - Returns: `true` if any descendant paragraph had a SEQ field rewritten.
     private func walkAndProcessBodyChildForFields(
         _ child: inout BodyChild,
@@ -290,84 +314,147 @@ extension WordDocument {
             counters[id, default: 0] += 1
             let newValue = counters[id]!
 
-            // Rewrite cachedResult run.
-            //
-            // Two forms (PsychQuant/che-word-mcp#104):
-            //
-            // 1. Baked form (v2.0.0 convention): `cachedResultRunIdx` points to
-            //    the SAME run that holds all 5 `<w:fldChar>` elements in its
-            //    `rawXML`. Use the regex-based `rewriteCachedResult` to splice
-            //    the new value into the embedded `<w:t>...</w:t>` between
-            //    `separate` and `end`.
-            //
-            // 2. Canonical 5-run form (post-roundtrip / native Word):
-            //    `cachedResultRunIdx` points to a DEDICATED run whose only
-            //    content is the cached value. After DocxReader, that run has
-            //    `rawXML == nil` and the value lives in `Run.text` (`<w:t>`
-            //    is in `recognizedRunChildren` at DocxReader.swift:1985 so it
-            //    isn't captured as raw). For native-emitted XML constructed by
-            //    hand, it may have `rawXML == "<w:t>1</w:t>"`. Either way, we
-            //    update `Run.text` directly — no regex needed.
-            if let idx = field.cachedResultRunIdx, idx < para.runs.count {
-                let cachedRun = para.runs[idx]
-                let isBakedForm = (cachedRun.rawXML?.contains("fldChar") ?? false)
-
-                if isBakedForm {
-                    let oldXML = cachedRun.rawXML ?? ""
-                    let (newXML, didMatch) = rewriteCachedResult(oldXML, newValue: "\(newValue)", matchingInstrText: field.instrText)
-                    if newXML != oldXML {
-                        para.runs[idx].rawXML = newXML
-                        rewroteSomething = true
-                    } else if !didMatch {
-                        // v0.13.5+ (#54 sub-finding #5): regex schema drift detection.
-                        // FieldParser saw a SEQ with a cached-result run, but our
-                        // rewrite regex couldn't locate the cached <w:t>...</w:t>
-                        // block. The cached value may now be stale.
-                        FileHandle.standardError.write(
-                            Data("Warning: updateAllFields could not rewrite cached value for SEQ '\(id)' (instrText: '\(field.instrText)'). Cached value may be stale; potential XML schema drift. (#54)\n".utf8)
-                        )
-                    }
-                } else {
-                    // Canonical 5-run form: dedicated cached-value run.
-                    //
-                    // The cached run can take two shapes:
-                    //
-                    // (a) Post-DocxReader: `rawXML == nil`, value lives in
-                    //     `Run.text`. Updating `text` round-trips because
-                    //     `Run.toXML()` falls through to the typed-text path.
-                    //
-                    // (b) Hand-built / native-Word emit / upstream tools:
-                    //     `rawXML == "<w:rPr>...</w:rPr><w:t>1</w:t>"` (or
-                    //     just `<w:t>1</w:t>`). `Run.toXML()` short-circuits
-                    //     on non-nil rawXML (Run.swift:246-248) — mutating
-                    //     `Run.text` alone would silently no-op the rewrite.
-                    //
-                    // Strategy: splice the new value into the embedded `<w:t>`
-                    // when rawXML is non-nil, AND keep `Run.text` in sync so
-                    // both surfaces report the new value consistently. This
-                    // matches the v0.21.10 #104 follow-up gap surfaced by
-                    // 6-AI verify — see ooxml-swift#27 (closed) and the
-                    // verify report at che-word-mcp#104.
-                    let newText = "\(newValue)"
-                    var rewrote = false
-                    if let rawXML = cachedRun.rawXML {
-                        let (newXML, didMatch) = rewriteCanonicalCachedText(rawXML, newValue: newText)
-                        if didMatch && newXML != rawXML {
-                            para.runs[idx].rawXML = newXML
-                            rewrote = true
-                        }
-                    }
-                    if cachedRun.text != newText {
-                        para.runs[idx].text = newText
-                        rewrote = true
-                    }
-                    if rewrote {
-                        rewroteSomething = true
-                    }
-                }
+            if rewriteCachedResult(for: field, in: &para, identifier: id, newValue: newValue) {
+                rewroteSomething = true
             }
         }
         return rewroteSomething
+    }
+
+    private func rewriteCachedResult(
+        for field: ParsedField,
+        in para: inout Paragraph,
+        identifier: String,
+        newValue: Int
+    ) -> Bool {
+        let newText = "\(newValue)"
+        switch field.location {
+        case .paragraphRun:
+            guard let idx = field.cachedResultRunIdx, idx < para.runs.count else { return false }
+            return rewriteCachedResultRun(
+                &para.runs[idx],
+                field: field,
+                identifier: identifier,
+                newText: newText
+            )
+
+        case .hyperlinkRun(let hyperlinkIndex):
+            guard hyperlinkIndex < para.hyperlinks.count,
+                  let idx = field.cachedResultRunIdx,
+                  idx < para.hyperlinks[hyperlinkIndex].runs.count else { return false }
+            return rewriteCachedResultRun(
+                &para.hyperlinks[hyperlinkIndex].runs[idx],
+                field: field,
+                identifier: identifier,
+                newText: newText
+            )
+
+        case .fieldSimple(let index):
+            guard index < para.fieldSimples.count else { return false }
+            if para.fieldSimples[index].runs.isEmpty {
+                para.fieldSimples[index].runs = [Run(text: newText)]
+                return true
+            }
+            return rewriteCachedResultRun(
+                &para.fieldSimples[index].runs[0],
+                field: field,
+                identifier: identifier,
+                newText: newText
+            )
+
+        case .alternateContentFallbackRun(let alternateContentIndex):
+            guard alternateContentIndex < para.alternateContents.count,
+                  let idx = field.cachedResultRunIdx,
+                  idx < para.alternateContents[alternateContentIndex].fallbackRuns.count else { return false }
+            let oldAC = para.alternateContents[alternateContentIndex]
+            let (newRawXML, didMatch) = rewriteCachedResult(
+                oldAC.rawXML,
+                newValue: newText,
+                matchingInstrText: field.instrText
+            )
+            guard didMatch, newRawXML != oldAC.rawXML else {
+                if !didMatch {
+                    emitCachedResultWarning(identifier: identifier, instrText: field.instrText)
+                }
+                return false
+            }
+            var updatedRuns = oldAC.fallbackRuns
+            _ = rewriteCachedResultRun(
+                &updatedRuns[idx],
+                field: field,
+                identifier: identifier,
+                newText: newText
+            )
+            para.alternateContents[alternateContentIndex] = AlternateContent(
+                rawXML: newRawXML,
+                fallbackRuns: updatedRuns,
+                position: oldAC.position
+            )
+            return true
+
+        case .contentControl(let index):
+            guard index < para.contentControls.count else { return false }
+            let oldXML = para.contentControls[index].content
+            let (newXML, didMatch) = rewriteCachedResult(
+                oldXML,
+                newValue: newText,
+                matchingInstrText: field.instrText
+            )
+            if newXML != oldXML {
+                para.contentControls[index].content = newXML
+                return true
+            }
+            if !didMatch {
+                emitCachedResultWarning(identifier: identifier, instrText: field.instrText)
+            }
+            return false
+        }
+    }
+
+    private func rewriteCachedResultRun(
+        _ run: inout Run,
+        field: ParsedField,
+        identifier: String,
+        newText: String
+    ) -> Bool {
+        let isBakedForm = (run.rawXML?.contains("fldChar") ?? false)
+
+        if isBakedForm {
+            let oldXML = run.rawXML ?? ""
+            let (newXML, didMatch) = rewriteCachedResult(
+                oldXML,
+                newValue: newText,
+                matchingInstrText: field.instrText
+            )
+            if newXML != oldXML {
+                run.rawXML = newXML
+                return true
+            }
+            if !didMatch {
+                emitCachedResultWarning(identifier: identifier, instrText: field.instrText)
+            }
+            return false
+        }
+
+        var rewrote = false
+        if let rawXML = run.rawXML {
+            let (newXML, didMatch) = rewriteCanonicalCachedText(rawXML, newValue: newText)
+            if didMatch && newXML != rawXML {
+                run.rawXML = newXML
+                rewrote = true
+            }
+        }
+        if run.text != newText {
+            run.text = newText
+            rewrote = true
+        }
+        return rewrote
+    }
+
+    private func emitCachedResultWarning(identifier: String, instrText: String) {
+        FileHandle.standardError.write(
+            Data("Warning: updateAllFields could not rewrite cached value for SEQ '\(identifier)' (instrText: '\(instrText)'). Cached value may be stale; potential XML schema drift. (#54)\n".utf8)
+        )
     }
 
     /// Returns heading level (1-9) if paragraph has `pStyle == "Heading N"`, else nil.

--- a/Sources/OOXMLSwift/Models/WordDocument+WrapCaptionSequenceFields.swift
+++ b/Sources/OOXMLSwift/Models/WordDocument+WrapCaptionSequenceFields.swift
@@ -310,10 +310,12 @@ extension WordDocument {
             ctx.nextBookmarkId += 1
             var startRun = Run(text: "")
             startRun.rawXML = "<w:bookmarkStart w:id=\"\(bookmarkId)\" w:name=\"\(escapeBookmarkName(bookmarkName))\"/>"
+            startRun.position = preRun.position
             newRuns.append(startRun)
             newRuns.append(seqRun)
             var endRun = Run(text: "")
             endRun.rawXML = "<w:bookmarkEnd w:id=\"\(bookmarkId)\"/>"
+            endRun.position = preRun.position
             newRuns.append(endRun)
         } else {
             newRuns.append(seqRun)

--- a/Sources/OOXMLSwift/Parsing/FieldParser.swift
+++ b/Sources/OOXMLSwift/Parsing/FieldParser.swift
@@ -53,6 +53,14 @@ extension ParsedFieldValue: Equatable {
 
 /// One recognized field span inside a paragraph, with run-index location info
 /// so CRUD tools can modify specific runs.
+public enum ParsedFieldLocation: Equatable {
+    case paragraphRun
+    case hyperlinkRun(hyperlinkIndex: Int)
+    case fieldSimple(index: Int)
+    case alternateContentFallbackRun(alternateContentIndex: Int)
+    case contentControl(index: Int)
+}
+
 public struct ParsedField: Equatable {
     public static func == (lhs: ParsedField, rhs: ParsedField) -> Bool {
         lhs.startRunIdx == rhs.startRunIdx
@@ -60,6 +68,7 @@ public struct ParsedField: Equatable {
             && lhs.cachedResultRunIdx == rhs.cachedResultRunIdx
             && lhs.instrText == rhs.instrText
             && lhs.field == rhs.field
+            && lhs.location == rhs.location
     }
 
     /// Index of the run containing `<w:fldChar fldCharType="begin">`.
@@ -73,19 +82,23 @@ public struct ParsedField: Equatable {
     public let instrText: String
     /// Parsed field value, dispatched from instrText.
     public let field: ParsedFieldValue
+    /// Paragraph surface where this field was found.
+    public let location: ParsedFieldLocation
 
     public init(
         startRunIdx: Int,
         endRunIdx: Int,
         cachedResultRunIdx: Int?,
         instrText: String,
-        field: ParsedFieldValue
+        field: ParsedFieldValue,
+        location: ParsedFieldLocation = .paragraphRun
     ) {
         self.startRunIdx = startRunIdx
         self.endRunIdx = endRunIdx
         self.cachedResultRunIdx = cachedResultRunIdx
         self.instrText = instrText
         self.field = field
+        self.location = location
     }
 }
 
@@ -108,13 +121,55 @@ public enum FieldParser {
     public static func parse(paragraph: Paragraph) -> [ParsedField] {
         var result: [ParsedField] = []
 
-        for (runIdx, run) in paragraph.runs.enumerated() {
+        result.append(contentsOf: parseRuns(paragraph.runs) { _ in .paragraphRun })
+
+        for (index, hyperlink) in paragraph.hyperlinks.enumerated() {
+            result.append(contentsOf: parseRuns(hyperlink.runs) { _ in
+                .hyperlinkRun(hyperlinkIndex: index)
+            })
+        }
+
+        for (index, fieldSimple) in paragraph.fieldSimples.enumerated() {
+            result.append(ParsedField(
+                startRunIdx: -1,
+                endRunIdx: -1,
+                cachedResultRunIdx: nil,
+                instrText: fieldSimple.instr,
+                field: dispatchParse(instrText: fieldSimple.instr),
+                location: .fieldSimple(index: index)
+            ))
+        }
+
+        for (index, alternateContent) in paragraph.alternateContents.enumerated() {
+            result.append(contentsOf: parseRuns(alternateContent.fallbackRuns) { _ in
+                .alternateContentFallbackRun(alternateContentIndex: index)
+            })
+        }
+
+        for (index, control) in paragraph.contentControls.enumerated() where !control.content.isEmpty {
+            result.append(contentsOf: parseFieldsInRawXML(
+                control.content,
+                atRunIdx: -1,
+                location: .contentControl(index: index)
+            ))
+        }
+
+        return result
+    }
+
+    private static func parseRuns(
+        _ runs: [Run],
+        locationForRun: (Int) -> ParsedFieldLocation
+    ) -> [ParsedField] {
+        var result: [ParsedField] = []
+
+        for (runIdx, run) in runs.enumerated() {
             guard let rawXML = run.rawXML else { continue }
             // Phase 1 marker: BOTH fldChar AND instrText in the same rawXML
             // means this run carries a baked-form 5-run block.
             guard rawXML.contains("fldChar"), rawXML.contains("instrText") else { continue }
 
-            let fields = parseFieldsInRawXML(rawXML, atRunIdx: runIdx)
+            let fields = parseFieldsInRawXML(rawXML, atRunIdx: runIdx, location: locationForRun(runIdx))
             result.append(contentsOf: fields)
         }
 
@@ -124,7 +179,7 @@ public enum FieldParser {
         // claimed by Phase 1. No real-world producer mixes the two in a single
         // paragraph; documenting the assumption is sufficient.)
         if result.isEmpty {
-            result.append(contentsOf: parseFiveRunSpan(paragraph: paragraph))
+            result.append(contentsOf: parseFiveRunSpan(runs: runs, locationForRun: locationForRun))
         }
 
         return result
@@ -134,7 +189,10 @@ public enum FieldParser {
     /// (begin / instrText / separate / cachedValue / end). State machine
     /// resets on out-of-order patterns to be robust against malformed
     /// paragraphs.
-    private static func parseFiveRunSpan(paragraph: Paragraph) -> [ParsedField] {
+    private static func parseFiveRunSpan(
+        runs: [Run],
+        locationForRun: (Int) -> ParsedFieldLocation
+    ) -> [ParsedField] {
         // State of an in-progress field span as we walk the runs.
         struct InProgress {
             var beginRunIdx: Int
@@ -178,7 +236,7 @@ public enum FieldParser {
             return pieces.joined()
         }
 
-        for (idx, run) in paragraph.runs.enumerated() {
+        for (idx, run) in runs.enumerated() {
             let fragments = runFragments(run)
             // Caption text runs (only `<w:t>`) carry no fldChar/instrText
             // signal. Treat them as neutral — they neither advance nor reset
@@ -237,7 +295,8 @@ public enum FieldParser {
                         endRunIdx: idx,
                         cachedResultRunIdx: span.cachedRunIdx,
                         instrText: instrText,
-                        field: parsedValue
+                        field: parsedValue,
+                        location: locationForRun(idx)
                     ))
                 }
                 current = nil
@@ -251,7 +310,11 @@ public enum FieldParser {
     /// Extract field spans from a single Run.rawXML containing one or more
     /// embedded 5-run field blocks. All parsed fields report the same runIdx
     /// (they're logically inside that one paragraph run).
-    private static func parseFieldsInRawXML(_ rawXML: String, atRunIdx runIdx: Int) -> [ParsedField] {
+    private static func parseFieldsInRawXML(
+        _ rawXML: String,
+        atRunIdx runIdx: Int,
+        location: ParsedFieldLocation
+    ) -> [ParsedField] {
         var results: [ParsedField] = []
 
         // Scan for <w:instrText ...>...</w:instrText> occurrences.
@@ -279,7 +342,8 @@ public enum FieldParser {
                 endRunIdx: runIdx,
                 cachedResultRunIdx: runIdx,  // Same run — rawXML-embedded form
                 instrText: instrText,
-                field: parsedValue
+                field: parsedValue,
+                location: location
             ))
         }
 

--- a/Tests/OOXMLSwiftTests/FieldParserTests.swift
+++ b/Tests/OOXMLSwiftTests/FieldParserTests.swift
@@ -121,4 +121,70 @@ final class FieldParserTests: XCTestCase {
         if case .styleRef = parsed[0].field {} else { XCTFail("Expected first to be styleRef") }
         if case .sequence = parsed[1].field {} else { XCTFail("Expected second to be sequence") }
     }
+
+    // MARK: Issue 26 wrapper surfaces
+
+    func testFieldParserHandlesFieldSimpleSEQ() {
+        var para = Paragraph()
+        para.fieldSimples = [
+            FieldSimple(instr: " SEQ Figure \\* ARABIC ", runs: [Run(text: "1")])
+        ]
+
+        let parsed = FieldParser.parse(paragraph: para)
+        XCTAssertEqual(parsed.count, 1)
+        guard let first = parsed.first, case .sequence(let seq) = first.field else {
+            return XCTFail("Expected .sequence")
+        }
+        XCTAssertEqual(seq.identifier, "Figure")
+    }
+
+    func testFieldParserHandlesInlineSDTSEQ() {
+        let field = SequenceField(identifier: "Figure", cachedResult: "1")
+        let sdt = StructuredDocumentTag(id: 2601, tag: "inline-seq")
+        var para = Paragraph()
+        para.contentControls = [
+            ContentControl(sdt: sdt, content: field.toFieldXML())
+        ]
+
+        let parsed = FieldParser.parse(paragraph: para)
+        XCTAssertEqual(parsed.count, 1)
+        guard let first = parsed.first, case .sequence(let seq) = first.field else {
+            return XCTFail("Expected .sequence")
+        }
+        XCTAssertEqual(seq.identifier, "Figure")
+    }
+
+    func testFieldParserHandlesHyperlinkWrappedSEQ() {
+        let field = SequenceField(identifier: "Figure", cachedResult: "1")
+        var run = Run(text: "")
+        run.rawXML = field.toFieldXML()
+        var link = Hyperlink.external(id: "h1", text: "", url: "https://example.com", relationshipId: "rId1")
+        link.runs = [run]
+        var para = Paragraph()
+        para.hyperlinks = [link]
+
+        let parsed = FieldParser.parse(paragraph: para)
+        XCTAssertEqual(parsed.count, 1)
+        guard let first = parsed.first, case .sequence(let seq) = first.field else {
+            return XCTFail("Expected .sequence")
+        }
+        XCTAssertEqual(seq.identifier, "Figure")
+    }
+
+    func testFieldParserHandlesAlternateContentFallbackSEQ() {
+        let field = SequenceField(identifier: "Figure", cachedResult: "1")
+        var run = Run(text: "")
+        run.rawXML = field.toFieldXML()
+        var para = Paragraph()
+        para.alternateContents = [
+            AlternateContent(rawXML: "<mc:AlternateContent/>", fallbackRuns: [run])
+        ]
+
+        let parsed = FieldParser.parse(paragraph: para)
+        XCTAssertEqual(parsed.count, 1)
+        guard let first = parsed.first, case .sequence(let seq) = first.field else {
+            return XCTFail("Expected .sequence")
+        }
+        XCTAssertEqual(seq.identifier, "Figure")
+    }
 }

--- a/Tests/OOXMLSwiftTests/Issue93WrapCaptionSeqPlacementTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue93WrapCaptionSeqPlacementTests.swift
@@ -175,6 +175,45 @@ final class Issue93WrapCaptionSeqPlacementTests: XCTestCase {
         }
     }
 
+    // MARK: - 24.1 Bookmark wrapper must stay with positioned SEQ splice
+
+    func testInsertBookmarkMarkersInheritSourceRunPosition() throws {
+        var doc = WordDocument()
+        var sourceRun = Run(text: "圖 4-1：前後期報酬率分布直方圖")
+        sourceRun.position = 1
+        doc.body.children = [.paragraph(Paragraph(runs: [sourceRun]))]
+
+        let pattern = try NSRegularExpression(pattern: "圖 4-(\\d+)：")
+        _ = try doc.wrapCaptionSequenceFields(
+            pattern: pattern,
+            sequenceName: "Figure",
+            insertBookmark: true,
+            bookmarkTemplate: "fig_${number}"
+        )
+
+        guard case .paragraph(let p) = doc.body.children[0] else {
+            return XCTFail("expected paragraph")
+        }
+
+        let bookmarkStartIdx = p.runs.firstIndex { ($0.rawXML ?? "").contains("bookmarkStart") }
+        let seqIdx = p.runs.firstIndex { ($0.rawXML ?? "").contains("SEQ Figure") }
+        let bookmarkEndIdx = p.runs.firstIndex { ($0.rawXML ?? "").contains("bookmarkEnd") }
+        let suffixIdx = p.runs.firstIndex { $0.text.hasPrefix("：") }
+
+        XCTAssertNotNil(bookmarkStartIdx, "bookmarkStart run must exist")
+        XCTAssertNotNil(seqIdx, "SEQ run must exist")
+        XCTAssertNotNil(bookmarkEndIdx, "bookmarkEnd run must exist")
+        XCTAssertNotNil(suffixIdx, "suffix run must exist")
+
+        if let start = bookmarkStartIdx, let seq = seqIdx, let end = bookmarkEndIdx, let suffix = suffixIdx {
+            XCTAssertLessThan(start, seq, "bookmarkStart must immediately precede the SEQ run")
+            XCTAssertLessThan(seq, end, "bookmarkEnd must follow the SEQ run")
+            XCTAssertLessThan(end, suffix, "bookmark wrapper must remain before trailing caption text")
+            XCTAssertEqual(p.runs[start].position, sourceRun.position)
+            XCTAssertEqual(p.runs[end].position, sourceRun.position)
+        }
+    }
+
     // MARK: - 93.4 ROUND-TRIP test: write to docx, read back, verify position
 
     /// The user's reproducer (kiki830621/collaboration_guo_analysis#5) observed

--- a/Tests/OOXMLSwiftTests/Issue94UpdateAllFieldsContainerCoverageTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue94UpdateAllFieldsContainerCoverageTests.swift
@@ -227,4 +227,99 @@ final class Issue94UpdateAllFieldsContainerCoverageTests: XCTestCase {
         XCTAssertEqual(cachedResultOfFirstSEQ(in: f3), "3",
             "Trailing top-level Figure must continue counter (3), not reset to 1 by container-nested heading")
     }
+
+    // MARK: - 25.1 Header/footer/notes recurse through bodyChildren too
+
+    func testUpdateAllFieldsRecursesIntoHeaderTableCellParagraphs() {
+        var doc = WordDocument()
+        var header = Header(id: "rIdHeader", type: .default, originalFileName: "header1.xml")
+        header.bodyChildren = [
+            .table(Table(rows: [
+                TableRow(cells: [
+                    TableCell(paragraphs: [captionParagraph(identifier: "Figure", initialCached: "0")])
+                ])
+            ]))
+        ]
+        doc.headers = [header]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Figure": 1])
+        XCTAssertTrue(doc.modifiedParts.contains("word/header1.xml"))
+
+        guard case .table(let table) = doc.headers[0].bodyChildren[0] else {
+            return XCTFail("expected header table")
+        }
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: table.rows[0].cells[0].paragraphs[0]), "1")
+    }
+
+    func testUpdateAllFieldsRecursesIntoFooterSDTChildParagraphs() {
+        var doc = WordDocument()
+        let sdt = StructuredDocumentTag(id: 2501, tag: "footer-seq")
+        let cc = ContentControl(sdt: sdt, content: "")
+        var footer = Footer(id: "rIdFooter", type: .default, originalFileName: "footer1.xml")
+        footer.bodyChildren = [
+            .contentControl(cc, children: [
+                .paragraph(captionParagraph(identifier: "Figure", initialCached: "1")),
+                .paragraph(captionParagraph(identifier: "Figure", initialCached: "1"))
+            ])
+        ]
+        doc.footers = [footer]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Figure": 2])
+        XCTAssertTrue(doc.modifiedParts.contains("word/footer1.xml"))
+
+        guard case .contentControl(_, let children) = doc.footers[0].bodyChildren[0],
+              case .paragraph(let p1) = children[0],
+              case .paragraph(let p2) = children[1] else {
+            return XCTFail("expected footer SDT paragraphs")
+        }
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: p1), "1")
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: p2), "2")
+    }
+
+    func testUpdateAllFieldsRecursesIntoFootnoteTableCellParagraphs() {
+        var doc = WordDocument()
+        var footnote = Footnote(id: 1, text: "", paragraphIndex: 0)
+        footnote.bodyChildren = [
+            .table(Table(rows: [
+                TableRow(cells: [
+                    TableCell(paragraphs: [captionParagraph(identifier: "Table", initialCached: "0")])
+                ])
+            ]))
+        ]
+        doc.footnotes.footnotes = [footnote]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Table": 1])
+        XCTAssertTrue(doc.modifiedParts.contains("word/footnotes.xml"))
+
+        guard case .table(let table) = doc.footnotes.footnotes[0].bodyChildren[0] else {
+            return XCTFail("expected footnote table")
+        }
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: table.rows[0].cells[0].paragraphs[0]), "1")
+    }
+
+    func testUpdateAllFieldsRecursesIntoEndnoteContainerSEQ() {
+        var doc = WordDocument()
+        let sdt = StructuredDocumentTag(id: 2601, tag: "endnote-seq")
+        let cc = ContentControl(sdt: sdt, content: "")
+        var endnote = Endnote(id: 1, text: "", paragraphIndex: 0)
+        endnote.bodyChildren = [
+            .contentControl(cc, children: [
+                .paragraph(captionParagraph(identifier: "Table", initialCached: "0"))
+            ])
+        ]
+        doc.endnotes.endnotes = [endnote]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Table": 1])
+        XCTAssertTrue(doc.modifiedParts.contains("word/endnotes.xml"))
+
+        guard case .contentControl(_, let children) = doc.endnotes.endnotes[0].bodyChildren[0],
+              case .paragraph(let p) = children[0] else {
+            return XCTFail("expected endnote SDT paragraph")
+        }
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: p), "1")
+    }
 }

--- a/Tests/OOXMLSwiftTests/UpdateAllFieldsTests.swift
+++ b/Tests/OOXMLSwiftTests/UpdateAllFieldsTests.swift
@@ -115,6 +115,67 @@ final class UpdateAllFieldsTests: XCTestCase {
         }
     }
 
+    // MARK: Issue 26 wrapper-surface rewrites
+
+    func testUpdateAllFieldsRewritesSEQInParagraphWrapperSurfaces() {
+        var doc = WordDocument()
+
+        var fieldSimplePara = Paragraph()
+        fieldSimplePara.fieldSimples = [
+            FieldSimple(instr: " SEQ Figure \\* ARABIC ", runs: [Run(text: "0")])
+        ]
+
+        var hyperlinkRun = Run(text: "")
+        hyperlinkRun.rawXML = SequenceField(identifier: "Figure", cachedResult: "0").toFieldXML()
+        var hyperlink = Hyperlink.external(id: "h1", text: "", url: "https://example.com", relationshipId: "rId1")
+        hyperlink.runs = [hyperlinkRun]
+        var hyperlinkPara = Paragraph()
+        hyperlinkPara.hyperlinks = [hyperlink]
+
+        let sdt = StructuredDocumentTag(id: 2601, tag: "inline-seq")
+        var contentControlPara = Paragraph()
+        contentControlPara.contentControls = [
+            ContentControl(
+                sdt: sdt,
+                content: SequenceField(identifier: "Figure", cachedResult: "0").toFieldXML()
+            )
+        ]
+
+        let fallbackXML = SequenceField(identifier: "Figure", cachedResult: "0").toFieldXML()
+        var fallbackRun = Run(text: "")
+        fallbackRun.rawXML = fallbackXML
+        var alternateContentPara = Paragraph()
+        alternateContentPara.alternateContents = [
+            AlternateContent(
+                rawXML: "<mc:AlternateContent><mc:Fallback>\(fallbackXML)</mc:Fallback></mc:AlternateContent>",
+                fallbackRuns: [fallbackRun]
+            )
+        ]
+
+        doc.body.children = [
+            .paragraph(fieldSimplePara),
+            .paragraph(hyperlinkPara),
+            .paragraph(contentControlPara),
+            .paragraph(alternateContentPara)
+        ]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Figure": 4])
+
+        guard case .paragraph(let updatedFieldSimplePara) = doc.body.children[0],
+              case .paragraph(let updatedHyperlinkPara) = doc.body.children[1],
+              case .paragraph(let updatedContentControlPara) = doc.body.children[2],
+              case .paragraph(let updatedAlternateContentPara) = doc.body.children[3] else {
+            return XCTFail("expected four paragraphs")
+        }
+
+        XCTAssertEqual(updatedFieldSimplePara.fieldSimples[0].runs[0].text, "1")
+        XCTAssertTrue(updatedHyperlinkPara.hyperlinks[0].runs[0].rawXML?.contains("<w:t>2</w:t>") ?? false)
+        XCTAssertTrue(updatedContentControlPara.contentControls[0].content.contains("<w:t>3</w:t>"))
+        XCTAssertTrue(updatedAlternateContentPara.alternateContents[0].rawXML.contains("<w:t>4</w:t>"))
+        XCTAssertTrue(updatedAlternateContentPara.alternateContents[0].fallbackRuns[0].rawXML?.contains("<w:t>4</w:t>") ?? false)
+    }
+
     // MARK: Empty document
 
     func testEmptyDocumentReturnsEmptyDict() {


### PR DESCRIPTION
## Summary
- Make bookmark markers inserted by `wrapCaptionSequenceFields(insertBookmark:true)` inherit the source run position.
- Reuse recursive body-child field traversal for headers, footers, footnotes, and endnotes.
- Expand `FieldParser.parse(paragraph:)` to detect SEQ fields in hyperlinks, fldSimple, alternate-content fallback runs, and inline content controls.
- Add wrapper-surface `updateAllFields` rewrites and regression coverage for #24, #25, and #26.

## Tests
- `swift test --filter 'UpdateAllFieldsTests|Issue93WrapCaptionSeqPlacementTests|Issue94UpdateAllFieldsContainerCoverageTests|FieldParserTests'`
- `swift test`

Refs #24, #25, #26
