### PR TITLE
Clean up comment IDs and insert location errors

### DIFF
--- a/Sources/OOXMLSwift/Models/Document.swift
+++ b/Sources/OOXMLSwift/Models/Document.swift
@@ -2395,7 +2395,7 @@ public struct WordDocument: Equatable {
         // 在段落中添加註解標記
         let actualIndex = paragraphIndices[paragraphIndex]
         if case .paragraph(var para) = body.children[actualIndex] {
-            para.commentIds.append(commentId)
+            para.appendLegacyCommentId(commentId)
             body.children[actualIndex] = .paragraph(para)
         }
 
@@ -2436,7 +2436,7 @@ public struct WordDocument: Equatable {
         if paragraphIndex >= 0 && paragraphIndex < paragraphIndices.count {
             let actualIndex = paragraphIndices[paragraphIndex]
             if case .paragraph(var para) = body.children[actualIndex] {
-                para.commentIds.removeAll { $0 == commentId }
+                para.removeLegacyCommentId(commentId)
                 body.children[actualIndex] = .paragraph(para)
             }
         }

--- a/Sources/OOXMLSwift/Models/InsertLocation.swift
+++ b/Sources/OOXMLSwift/Models/InsertLocation.swift
@@ -25,7 +25,7 @@ public enum InsertLocation: Equatable {
 }
 
 /// Error thrown when an `InsertLocation` cannot be resolved in the target document.
-public enum InsertLocationError: Error, Equatable {
+public enum InsertLocationError: Error, Equatable, LocalizedError {
     case invalidParagraphIndex(Int)
     case imageIdNotFound(String)
     case tableIndexOutOfRange(Int)
@@ -39,6 +39,23 @@ public enum InsertLocationError: Error, Equatable {
     /// anchor kind". This dedicated case lets callers distinguish the two
     /// failures cleanly.
     case inlineModeRequiresParagraphIndex
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidParagraphIndex(let idx):
+            return "Paragraph index \(idx) is out of range for the document."
+        case .imageIdNotFound(let relationshipId):
+            return "No image with relationship id '\(relationshipId)' was found in the document."
+        case .tableIndexOutOfRange(let idx):
+            return "Table index \(idx) is out of range for the document."
+        case .tableCellOutOfRange(let tableIndex, let row, let col):
+            return "Table cell (table \(tableIndex), row \(row), col \(col)) is out of range."
+        case .textNotFound(let searchText, let instance):
+            return "Could not find instance \(instance) of text '\(searchText)' in the document."
+        case .inlineModeRequiresParagraphIndex:
+            return "Inline equations only support paragraphIndex anchors. Use a different anchor type or switch to displayMode: true."
+        }
+    }
 }
 
 // MARK: - Document resolution

--- a/Sources/OOXMLSwift/Models/Paragraph.swift
+++ b/Sources/OOXMLSwift/Models/Paragraph.swift
@@ -7,8 +7,20 @@ public struct Paragraph: Equatable {
     public var hasPageBreak: Bool = false      // 是否為分頁符段落
     public var bookmarks: [Bookmark] = []      // 段落內的書籤
     public var hyperlinks: [Hyperlink] = []    // 段落內的超連結
+    private var legacyCommentIds: [Int] = []
     @available(*, deprecated, message: "Use commentRangeMarkers (source of truth since Phase 4) or the computed commentRangeIds. Stored commentIds is no longer populated by Reader since v0.21.4 and will be removed in v0.22.")
-    public var commentIds: [Int] = []          // 段落關聯的註解 ID（v0.21.4+ deprecated — Reader 不再填值）
+    public var commentIds: [Int] {             // 段落關聯的註解 ID（v0.21.4+ deprecated — Reader 不再填值）
+        get { legacyCommentIds }
+        set { legacyCommentIds = newValue }
+    }
+    internal mutating func appendLegacyCommentId(_ commentId: Int) {
+        legacyCommentIds.append(commentId)
+    }
+
+    internal mutating func removeLegacyCommentId(_ commentId: Int) {
+        legacyCommentIds.removeAll { $0 == commentId }
+    }
+
     public var footnoteIds: [Int] = []         // 段落內的腳註 ID
     public var endnoteIds: [Int] = []          // 段落內的尾註 ID
     public var revisions: [Revision] = []      // 段落內的修訂記錄（w:ins/w:del）
@@ -406,7 +418,7 @@ extension Paragraph {
         }
 
         // 註解範圍開始標記
-        for commentId in commentIds {
+        for commentId in legacyCommentIds {
             xml += "<w:commentRangeStart w:id=\"\(commentId)\"/>"
         }
 
@@ -443,7 +455,7 @@ extension Paragraph {
         }
 
         // 註解範圍結束標記和參照
-        for commentId in commentIds {
+        for commentId in legacyCommentIds {
             xml += "<w:commentRangeEnd w:id=\"\(commentId)\"/>"
             xml += "<w:r><w:commentReference w:id=\"\(commentId)\"/></w:r>"
         }
@@ -549,7 +561,7 @@ extension Paragraph {
         // source-loaded commentRangeMarker, preserving R2 P0-5 no-double-emit
         // semantics while restoring R3-NEW-3 insertComment marker output.
         let commentIdsCoveredByMarkers = Set(commentRangeMarkers.map { $0.id })
-        for commentId in commentIds where !commentIdsCoveredByMarkers.contains(commentId) {
+        for commentId in legacyCommentIds where !commentIdsCoveredByMarkers.contains(commentId) {
             xml += "<w:commentRangeStart w:id=\"\(commentId)\"/>"
         }
 
@@ -733,7 +745,7 @@ extension Paragraph {
         // skipping a covered id avoids double-emit of end markers AND prevents
         // duplicating an inline reference run that the source-loaded paragraph
         // already carries (parsed as a Run with rawElements).
-        for commentId in commentIds where !commentIdsCoveredByMarkers.contains(commentId) {
+        for commentId in legacyCommentIds where !commentIdsCoveredByMarkers.contains(commentId) {
             xml += "<w:commentRangeEnd w:id=\"\(commentId)\"/>"
             xml += "<w:r><w:commentReference w:id=\"\(commentId)\"/></w:r>"
         }

--- a/Tests/OOXMLSwiftTests/InsertLocationTests.swift
+++ b/Tests/OOXMLSwiftTests/InsertLocationTests.swift
@@ -216,4 +216,27 @@ final class InsertLocationTests: XCTestCase {
         )
         XCTAssertEqual(doc.body.children.count, 2)
     }
+
+    func testInsertLocationErrorDescriptionsCoverEveryCase() {
+        let cases: [(InsertLocationError, [String])] = [
+            (.invalidParagraphIndex(7), ["Paragraph index 7", "out of range"]),
+            (.imageIdNotFound("rId404"), ["rId404", "No image"]),
+            (.tableIndexOutOfRange(3), ["Table index 3", "out of range"]),
+            (.tableCellOutOfRange(tableIndex: 2, row: 4, col: 6), ["table 2", "row 4", "col 6"]),
+            (.textNotFound(searchText: "needle", instance: 2), ["instance 2", "needle"]),
+            (.inlineModeRequiresParagraphIndex, ["Inline equations", "paragraphIndex"])
+        ]
+
+        for (error, expectedFragments) in cases {
+            let description = error.errorDescription
+            XCTAssertNotNil(description)
+            XCTAssertFalse(description?.isEmpty ?? true)
+            for fragment in expectedFragments {
+                XCTAssertTrue(
+                    description?.contains(fragment) ?? false,
+                    "Expected '\(description ?? "")' to contain '\(fragment)'"
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Move deprecated `Paragraph.commentIds` to a computed compatibility layer backed by private storage, and update internal emit/mutation sites to avoid self-deprecation warnings.
- Add `LocalizedError` descriptions for every `InsertLocationError` case.
- Add coverage for InsertLocation error descriptions.

## Tests
- `swift build`
- `swift test --filter InsertLocationTests|ParagraphTests|Issue56RoundtripCompletenessTests|Issue6RoundtripLoudFailTests`
- `swift test`

Refs #18, #20