### PR TITLE
Document parseRun namespace asymmetry

### DIFF
--- a/Sources/OOXMLSwift/IO/DocxReader.swift
+++ b/Sources/OOXMLSwift/IO/DocxReader.swift
@@ -2055,6 +2055,17 @@ public struct DocxReader {
         // children) via complementary mechanisms. Keep local until parseRun
         // gains a second pre-consumer that would benefit from `@testable`
         // introspection.
+        //
+        // Foreign-namespace asymmetry note (#19): the typed `rPr` lookup above
+        // is prefix-qualified (`elements(forName: "w:rPr")`), while this
+        // allowlist is prefix-agnostic (`localName == "rPr"`). A malformed
+        // `<x:rPr xmlns:x="other-ns">` direct child is therefore neither parsed
+        // as run properties nor preserved as `rawElements`. This mirrors the
+        // documented paragraph-level `pPr` policy from #14: ECMA-376 defines
+        // run properties here as `<w:rPr>`, so silent-drop is the conservative
+        // response to foreign-namespace lookalikes. If a real producer emits
+        // meaningful foreign-namespace `rPr`, migrate this to a namespace-aware
+        // `(localName, namespaceURI)` check instead of widening the allowlist.
         let recognizedRunChildren: Set<String> = ["rPr", "t", "drawing", "oMath", "oMathPara"]
         var collectedRawElements: [RawElement] = []
         for child in element.children ?? [] {

--- a/Tests/OOXMLSwiftTests/Issue19NamespacePrefixAsymmetryTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue19NamespacePrefixAsymmetryTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import OOXMLSwift
+
+/// Regression coverage for PsychQuant/ooxml-swift#19.
+///
+/// `parseRun` intentionally treats typed `<w:rPr>` lookup as prefix-qualified
+/// while its raw-child skip list uses `localName`. This pins the documented
+/// malformed-input policy: a foreign-namespace `<x:rPr>` lookalike is silently
+/// dropped, not parsed as WordprocessingML run properties and not preserved as
+/// raw XML.
+final class Issue19NamespacePrefixAsymmetryTests: XCTestCase {
+
+    func testForeignNamespaceRPrLookalikeIsDocumentedSilentDrop() throws {
+        let element = try XMLElement(xmlString: """
+        <w:r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+             xmlns:x="urn:foreign">
+          <x:rPr>
+            <x:b/>
+          </x:rPr>
+          <w:t>body</w:t>
+          <x:custom>keep me</x:custom>
+        </w:r>
+        """)
+
+        let run = try DocxReader.parseRun(
+            from: element,
+            relationships: RelationshipsCollection()
+        )
+
+        XCTAssertEqual(run.text, "body")
+        XCTAssertFalse(run.properties.bold, "foreign-namespace rPr must not be parsed as OOXML run properties")
+
+        let rawElements = run.rawElements ?? []
+        let rawNames = rawElements.map(\.name)
+        XCTAssertFalse(rawNames.contains("rPr"), "foreign-namespace rPr is intentionally skipped by localName allowlist")
+        XCTAssertEqual(rawNames, ["custom"], "unrelated foreign children should still be preserved as rawElements")
+        XCTAssertEqual(rawElements.first?.xml.contains("<x:custom>keep me</x:custom>"), true)
+    }
+}


### PR DESCRIPTION
## Summary
- Document the `parseRun` foreign-namespace `rPr` silent-drop policy next to the `recognizedRunChildren` allowlist.
- Add a regression test pinning the malformed `<x:rPr>` behavior while proving unrelated foreign children still preserve through `rawElements`.

## Tests
- `swift test --filter Issue19NamespacePrefixAsymmetryTests`
- `swift test`

Refs #19