### PR TITLE
Cover canonical sequence field edge cases

### DIFF
--- a/Sources/OOXMLSwift/Parsing/FieldParser.swift
+++ b/Sources/OOXMLSwift/Parsing/FieldParser.swift
@@ -133,7 +133,8 @@ public enum FieldParser {
     /// Phase-2 walker: detect SEQ fields emitted as 5 separate `<w:r>` runs
     /// (begin / instrText / separate / cachedValue / end). State machine
     /// resets on out-of-order patterns to be robust against malformed
-    /// paragraphs.
+    /// paragraphs. A truncated span that reaches paragraph end without a
+    /// closing `fldCharType="end"` is discarded and emits no `ParsedField`.
     private static func parseFiveRunSpan(paragraph: Paragraph) -> [ParsedField] {
         // State of an in-progress field span as we walk the runs.
         struct InProgress {

--- a/Tests/OOXMLSwiftTests/Issue104FieldParserCanonicalFormTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue104FieldParserCanonicalFormTests.swift
@@ -24,6 +24,48 @@ import XCTest
 ///   hyperlink / fieldSimple / alternateContent)
 final class Issue104FieldParserCanonicalFormTests: XCTestCase {
 
+    // MARK: - Helpers
+
+    private func canonicalSEQFieldRuns(identifier: String, cachedResult: String = "999") -> [Run] {
+        var beginRun = Run(text: "")
+        beginRun.rawXML = "<w:fldChar w:fldCharType=\"begin\"/>"
+
+        var instrRun = Run(text: "")
+        instrRun.rawXML = "<w:instrText xml:space=\"preserve\"> SEQ \(identifier) \\* ARABIC </w:instrText>"
+
+        var separateRun = Run(text: "")
+        separateRun.rawXML = "<w:fldChar w:fldCharType=\"separate\"/>"
+
+        var cachedRun = Run(text: cachedResult)
+        cachedRun.rawXML = "<w:t xml:space=\"preserve\">\(cachedResult)</w:t>"
+
+        var endRun = Run(text: "")
+        endRun.rawXML = "<w:fldChar w:fldCharType=\"end\"/>"
+
+        return [beginRun, instrRun, separateRun, cachedRun, endRun]
+    }
+
+    private func canonicalSEQParagraph(
+        identifier: String,
+        cachedResult: String = "999",
+        prefix: String = ""
+    ) -> Paragraph {
+        var para = Paragraph()
+        para.runs = prefix.isEmpty ? [] : [Run(text: prefix)]
+        para.runs.append(contentsOf: canonicalSEQFieldRuns(identifier: identifier, cachedResult: cachedResult))
+        para.properties.style = "Caption"
+        return para
+    }
+
+    private func sequenceIdentifiers(_ fields: [ParsedField]) -> [String] {
+        fields.compactMap { field in
+            if case .sequence(let seq) = field.field {
+                return seq.identifier
+            }
+            return nil
+        }
+    }
+
     // MARK: - 104.1 Primary RED reproducer: roundtrip via Writer → Reader
 
     /// The exact reproducer from che-word-mcp#104: build a paragraph via
@@ -158,6 +200,128 @@ final class Issue104FieldParserCanonicalFormTests: XCTestCase {
             "endRunIdx should point to the run containing fldCharType=end (run index 7)")
         XCTAssertEqual(field.cachedResultRunIdx, 6,
             "cachedResultRunIdx should point to the standalone <w:t> run between separate and end (run index 6)")
+    }
+
+    // MARK: - #29: SEQ Table identifier coverage
+
+    func testFieldParserHandlesCanonical5RunSEQTableIdentifier() {
+        let para = canonicalSEQParagraph(identifier: "Table", prefix: "Table 1: ")
+
+        let fields = FieldParser.parse(paragraph: para)
+
+        XCTAssertEqual(fields.count, 1)
+        XCTAssertEqual(sequenceIdentifiers(fields), ["Table"])
+        guard let field = fields.first,
+              case .sequence(let seq) = field.field else {
+            return XCTFail("expected one .sequence Table field")
+        }
+        XCTAssertEqual(seq.identifier, "Table")
+        XCTAssertEqual(field.cachedResultRunIdx, 4)
+    }
+
+    // MARK: - #30: multi-paragraph canonical counter accumulation
+
+    func testUpdateAllFieldsCountsCanonicalFigureAndTableAcrossNineteenParagraphs() {
+        let identifiers = [
+            "Figure", "Table", "Figure", "Table", "Figure",
+            "Figure", "Table", "Figure", "Table", "Figure",
+            "Figure", "Table", "Figure", "Figure", "Table",
+            "Figure", "Table", "Figure", "Figure"
+        ]
+
+        var doc = WordDocument()
+        doc.body.children = identifiers.enumerated().map { index, identifier in
+            .paragraph(canonicalSEQParagraph(
+                identifier: identifier,
+                prefix: "\(identifier) caption \(index + 1): "
+            ))
+        }
+
+        let result = doc.updateAllFields()
+
+        XCTAssertEqual(result, ["Figure": 12, "Table": 7])
+
+        var figureValues: [String] = []
+        var tableValues: [String] = []
+        for (index, child) in doc.body.children.enumerated() {
+            guard case .paragraph(let paragraph) = child else {
+                XCTFail("expected paragraph at body child \(index)")
+                continue
+            }
+
+            let identifier = identifiers[index]
+            let cachedRun = paragraph.runs[4]
+            if identifier == "Figure" {
+                figureValues.append(cachedRun.text)
+            } else {
+                tableValues.append(cachedRun.text)
+            }
+
+            XCTAssertTrue(
+                (cachedRun.rawXML ?? "").contains(">\(cachedRun.text)<"),
+                "cached rawXML should be rewritten in sync with Run.text for \(identifier) at index \(index); got \(cachedRun.rawXML ?? "<nil>")"
+            )
+            XCTAssertFalse(
+                (cachedRun.rawXML ?? "").contains(">999<"),
+                "stale cached value should not survive updateAllFields for \(identifier) at index \(index)"
+            )
+        }
+
+        XCTAssertEqual(figureValues, (1...12).map(String.init))
+        XCTAssertEqual(tableValues, (1...7).map(String.init))
+    }
+
+    // MARK: - #31: canonical state-machine edge cases
+
+    func testFieldParserHandlesTwoCanonicalSEQFieldsInOneParagraph() {
+        var para = Paragraph()
+        para.runs = [Run(text: "Figures: ")]
+            + canonicalSEQFieldRuns(identifier: "Figure", cachedResult: "99")
+            + [Run(text: " and ")]
+            + canonicalSEQFieldRuns(identifier: "Figure", cachedResult: "88")
+
+        let fields = FieldParser.parse(paragraph: para)
+
+        XCTAssertEqual(fields.count, 2)
+        XCTAssertEqual(sequenceIdentifiers(fields), ["Figure", "Figure"])
+        XCTAssertEqual(fields.map(\.cachedResultRunIdx), [4, 10])
+    }
+
+    func testUpdateAllFieldsCountsMixedCanonicalSEQFieldsInOneParagraph() {
+        var para = Paragraph()
+        para.runs = [Run(text: "Mixed: ")]
+            + canonicalSEQFieldRuns(identifier: "Figure", cachedResult: "99")
+            + [Run(text: " / ")]
+            + canonicalSEQFieldRuns(identifier: "Table", cachedResult: "88")
+
+        let fields = FieldParser.parse(paragraph: para)
+        XCTAssertEqual(sequenceIdentifiers(fields), ["Figure", "Table"])
+
+        var doc = WordDocument()
+        doc.body.children = [.paragraph(para)]
+
+        let result = doc.updateAllFields()
+
+        XCTAssertEqual(result, ["Figure": 1, "Table": 1])
+        guard case .paragraph(let updatedPara) = doc.body.children[0] else {
+            return XCTFail("expected paragraph after updateAllFields")
+        }
+
+        XCTAssertEqual(updatedPara.runs[4].text, "1")
+        XCTAssertEqual(updatedPara.runs[10].text, "1")
+        XCTAssertTrue((updatedPara.runs[4].rawXML ?? "").contains(">1<"))
+        XCTAssertTrue((updatedPara.runs[10].rawXML ?? "").contains(">1<"))
+        XCTAssertFalse((updatedPara.runs[4].rawXML ?? "").contains(">99<"))
+        XCTAssertFalse((updatedPara.runs[10].rawXML ?? "").contains(">88<"))
+    }
+
+    func testFieldParserIgnoresTruncatedCanonicalSEQSpanWithoutEnd() {
+        var para = Paragraph()
+        para.runs = Array(canonicalSEQFieldRuns(identifier: "Figure").prefix(2))
+
+        let fields = FieldParser.parse(paragraph: para)
+
+        XCTAssertTrue(fields.isEmpty, "begin + instrText without separate/cached/end must not emit a partial ParsedField")
     }
 
     // MARK: - 104.4 Native-Word 5-run + updateAllFields rewrite + emit roundtrip


### PR DESCRIPTION
## Summary
- Add canonical 5-run SEQ Table identifier coverage.
- Add 19-paragraph canonical Figure/Table counter accumulation coverage.
- Add same-paragraph multiple SEQ field and truncated-span state-machine coverage.
- Document that truncated canonical spans are discarded without emitting partial ParsedFields.

## Tests
- `swift test --filter Issue104FieldParserCanonicalFormTests`
- `swift test`

Refs #29, #30, #31