### PR TITLE
Add math-script-insensitive anchor lookup

### DIFF
--- a/Sources/OOXMLSwift/Models/InsertLocation.swift
+++ b/Sources/OOXMLSwift/Models/InsertLocation.swift
@@ -20,8 +20,100 @@ public enum InsertLocation: Equatable {
     case afterImageId(String)
     case afterTableIndex(Int)
     case intoTableCell(tableIndex: Int, row: Int, col: Int)
-    case afterText(String, instance: Int)
-    case beforeText(String, instance: Int)
+    case afterText(String, instance: Int, options: AnchorLookupOptions = .exact)
+    case beforeText(String, instance: Int, options: AnchorLookupOptions = .exact)
+}
+
+/// Options for text-anchor lookup used by `findBodyChildContainingText` and
+/// `InsertLocation.afterText` / `.beforeText`.
+public struct AnchorLookupOptions: Equatable, Sendable {
+    /// When enabled, Unicode subscript/superscript variants such as `H₀` and
+    /// `xᵢ` are canonicalized to ASCII-like text (`H0`, `xi`) on both the
+    /// haystack and needle before matching. Exact matching remains the default.
+    public var mathScriptInsensitive: Bool
+
+    public init(mathScriptInsensitive: Bool = false) {
+        self.mathScriptInsensitive = mathScriptInsensitive
+    }
+
+    public static let exact = AnchorLookupOptions()
+}
+
+public extension AnchorLookupOptions {
+    /// Canonicalize known Unicode subscript/superscript glyphs to the closest
+    /// ASCII representation. Characters outside the explicit table are left
+    /// unchanged so this does not become broad Unicode folding.
+    static func canonicalizeMathScriptVariants(_ text: String) -> String {
+        var result = ""
+        for scalar in text.unicodeScalars {
+            if let replacement = Self.mathScriptVariantMap[scalar] {
+                result += replacement
+            } else {
+                result += String(scalar)
+            }
+        }
+        return result
+    }
+
+    internal func contains(_ needle: String, in haystack: String) -> Bool {
+        guard mathScriptInsensitive else {
+            return haystack.contains(needle)
+        }
+        return Self.canonicalizeMathScriptVariants(haystack)
+            .contains(Self.canonicalizeMathScriptVariants(needle))
+    }
+}
+
+private extension AnchorLookupOptions {
+    static let mathScriptVariantMap: [UnicodeScalar: String] = {
+        var map: [UnicodeScalar: String] = [:]
+        func add(_ glyph: String, _ replacement: String) {
+            guard let scalar = glyph.unicodeScalars.first else { return }
+            map[scalar] = replacement
+        }
+
+        let subscriptDigits = [
+            ("₀", "0"), ("₁", "1"), ("₂", "2"), ("₃", "3"), ("₄", "4"),
+            ("₅", "5"), ("₆", "6"), ("₇", "7"), ("₈", "8"), ("₉", "9"),
+        ]
+        let superscriptDigits = [
+            ("⁰", "0"), ("¹", "1"), ("²", "2"), ("³", "3"), ("⁴", "4"),
+            ("⁵", "5"), ("⁶", "6"), ("⁷", "7"), ("⁸", "8"), ("⁹", "9"),
+        ]
+        let scriptSymbols = [
+            ("₊", "+"), ("⁺", "+"),
+            ("₋", "-"), ("⁻", "-"),
+            ("₌", "="), ("⁼", "="),
+            ("₍", "("), ("⁽", "("),
+            ("₎", ")"), ("⁾", ")"),
+        ]
+        let subscriptLetters = [
+            ("ₐ", "a"), ("ₑ", "e"), ("ₕ", "h"), ("ᵢ", "i"), ("ⱼ", "j"),
+            ("ₖ", "k"), ("ₗ", "l"), ("ₘ", "m"), ("ₙ", "n"), ("ₒ", "o"),
+            ("ₚ", "p"), ("ᵣ", "r"), ("ₛ", "s"), ("ₜ", "t"), ("ᵤ", "u"),
+            ("ᵥ", "v"), ("ₓ", "x"),
+        ]
+        let superscriptLetters = [
+            ("ᵃ", "a"), ("ᵇ", "b"), ("ᶜ", "c"), ("ᵈ", "d"), ("ᵉ", "e"),
+            ("ᶠ", "f"), ("ᵍ", "g"), ("ʰ", "h"), ("ⁱ", "i"), ("ʲ", "j"),
+            ("ᵏ", "k"), ("ˡ", "l"), ("ᵐ", "m"), ("ⁿ", "n"), ("ᵒ", "o"),
+            ("ᵖ", "p"), ("ʳ", "r"), ("ˢ", "s"), ("ᵗ", "t"), ("ᵘ", "u"),
+            ("ᵛ", "v"), ("ʷ", "w"), ("ˣ", "x"), ("ʸ", "y"), ("ᶻ", "z"),
+            ("ᴬ", "A"), ("ᴮ", "B"), ("ᴰ", "D"), ("ᴱ", "E"), ("ᴳ", "G"),
+            ("ᴴ", "H"), ("ᴵ", "I"), ("ᴶ", "J"), ("ᴷ", "K"), ("ᴸ", "L"),
+            ("ᴹ", "M"), ("ᴺ", "N"), ("ᴼ", "O"), ("ᴾ", "P"), ("ᴿ", "R"),
+            ("ᵀ", "T"), ("ᵁ", "U"), ("ⱽ", "V"), ("ᵂ", "W"),
+        ]
+
+        for (glyph, replacement) in subscriptDigits
+            + superscriptDigits
+            + scriptSymbols
+            + subscriptLetters
+            + superscriptLetters {
+            add(glyph, replacement)
+        }
+        return map
+    }()
 }
 
 /// Error thrown when an `InsertLocation` cannot be resolved in the target document.
@@ -112,14 +204,14 @@ extension WordDocument {
             table.rows[row].cells[col].paragraphs.append(paragraph)
             body.children[bodyIdx] = .table(table)
 
-        case .afterText(let searchText, let instance):
-            guard let bodyIdx = findBodyChildContainingText(searchText, nthInstance: instance) else {
+        case .afterText(let searchText, let instance, let options):
+            guard let bodyIdx = findBodyChildContainingText(searchText, nthInstance: instance, options: options) else {
                 throw InsertLocationError.textNotFound(searchText: searchText, instance: instance)
             }
             body.children.insert(.paragraph(paragraph), at: bodyIdx + 1)
 
-        case .beforeText(let searchText, let instance):
-            guard let bodyIdx = findBodyChildContainingText(searchText, nthInstance: instance) else {
+        case .beforeText(let searchText, let instance, let options):
+            guard let bodyIdx = findBodyChildContainingText(searchText, nthInstance: instance, options: options) else {
                 throw InsertLocationError.textNotFound(searchText: searchText, instance: instance)
             }
             body.children.insert(.paragraph(paragraph), at: bodyIdx)
@@ -187,11 +279,15 @@ extension WordDocument {
     /// consumers (rescue scripts, dxedit CLI, third-party tooling) previously
     /// had to reimplement this with diverging semantics. Exposing the canonical
     /// implementation eliminates that fragmentation.
-    public func findBodyChildContainingText(_ needle: String, nthInstance: Int = 1) -> Int? {
+    public func findBodyChildContainingText(
+        _ needle: String,
+        nthInstance: Int = 1,
+        options: AnchorLookupOptions = .exact
+    ) -> Int? {
         guard nthInstance >= 1, !needle.isEmpty else { return nil }
         var seen = 0
         for (i, child) in body.children.enumerated() {
-            if Self.bodyChildContainsText(child, needle: needle) {
+            if Self.bodyChildContainsText(child, needle: needle, options: options) {
                 seen += 1
                 if seen == nthInstance { return i }
             }
@@ -217,14 +313,18 @@ extension WordDocument {
     /// Public since v0.21.7 (PsychQuant/che-word-mcp#86) — exposed as a primitive
     /// for callers who want to check a single `BodyChild` without the
     /// `nthInstance` enumeration done by `findBodyChildContainingText`.
-    public static func bodyChildContainsText(_ child: BodyChild, needle: String) -> Bool {
+    public static func bodyChildContainsText(
+        _ child: BodyChild,
+        needle: String,
+        options: AnchorLookupOptions = .exact
+    ) -> Bool {
         switch child {
         case .paragraph(let para):
-            return para.flattenedDisplayText().contains(needle)
+            return options.contains(needle, in: para.flattenedDisplayText())
         case .table(let table):
-            return tableContainsText(table, needle: needle)
+            return tableContainsText(table, needle: needle, options: options)
         case .contentControl(_, let kids):
-            return kids.contains { bodyChildContainsText($0, needle: needle) }
+            return kids.contains { bodyChildContainsText($0, needle: needle, options: options) }
         case .bookmarkMarker:
             return false
         case .rawBlockElement:
@@ -238,14 +338,18 @@ extension WordDocument {
     /// Public since v0.21.7 (PsychQuant/che-word-mcp#86) — exposed alongside
     /// `bodyChildContainsText` so callers building custom traversal can reuse
     /// the depth-bounded table walk.
-    public static func tableContainsText(_ table: Table, needle: String) -> Bool {
+    public static func tableContainsText(
+        _ table: Table,
+        needle: String,
+        options: AnchorLookupOptions = .exact
+    ) -> Bool {
         for row in table.rows {
             for cell in row.cells {
                 for para in cell.paragraphs {
-                    if para.flattenedDisplayText().contains(needle) { return true }
+                    if options.contains(needle, in: para.flattenedDisplayText()) { return true }
                 }
                 for nested in cell.nestedTables {
-                    if tableContainsText(nested, needle: needle) { return true }
+                    if tableContainsText(nested, needle: needle, options: options) { return true }
                 }
             }
         }

--- a/Sources/OOXMLSwift/Models/InsertLocation.swift
+++ b/Sources/OOXMLSwift/Models/InsertLocation.swift
@@ -27,9 +27,23 @@ public enum InsertLocation: Equatable {
 /// Options for text-anchor lookup used by `findBodyChildContainingText` and
 /// `InsertLocation.afterText` / `.beforeText`.
 public struct AnchorLookupOptions: Equatable, Sendable {
-    /// When enabled, Unicode subscript/superscript variants such as `H₀` and
-    /// `xᵢ` are canonicalized to ASCII-like text (`H0`, `xi`) on both the
-    /// haystack and needle before matching. Exact matching remains the default.
+    /// When enabled, math-script Unicode forms are folded to ASCII-like text on
+    /// both haystack and needle before matching. Three folding classes apply:
+    ///
+    ///   1. Subscript / superscript variants (`H₀` ↔ `H0`, `xᵢ` ↔ `xi`).
+    ///      Latin sub/super letters, digits, and operators in U+2070..U+209C
+    ///      and the Latin-1 historical scripts (U+00B2/³/¹) are mapped.
+    ///   2. Greek subscripts (`xᵦ` ↔ `xβ`) for U+1D66..U+1D6A.
+    ///   3. Combining-mark accents on math letters (`X̄` ↔ `X`, `ŷ` ↔ `y`,
+    ///      `α̇` ↔ `α`). The matcher applies Unicode NFD decomposition and
+    ///      strips nonspacing marks so OMML accent emission (which omits the
+    ///      mark, see `MathAccent.visibleText`) round-trips against
+    ///      user-typed combined forms.
+    ///
+    /// Note: combining-mark stripping also folds language diacritics (`café` →
+    /// `cafe`). This is intentional for math-anchor matching but means callers
+    /// who need exact-with-accents must keep the default `.exact`.
+    /// Exact matching remains the default.
     public var mathScriptInsensitive: Bool
 
     public init(mathScriptInsensitive: Bool = false) {
@@ -40,16 +54,25 @@ public struct AnchorLookupOptions: Equatable, Sendable {
 }
 
 public extension AnchorLookupOptions {
-    /// Canonicalize known Unicode subscript/superscript glyphs to the closest
-    /// ASCII representation. Characters outside the explicit table are left
-    /// unchanged so this does not become broad Unicode folding.
+    /// Canonicalize Unicode math-script variants and combining accents to the
+    /// closest ASCII / base-letter representation. Characters outside the
+    /// explicit table and not under a combining mark are left unchanged.
     static func canonicalizeMathScriptVariants(_ text: String) -> String {
+        // NFD decompose so combining macron / acute / hat / dot / tilde land
+        // on their own scalar after the base, then drop nonspacing marks. This
+        // turns X̄ into X regardless of whether the source was precomposed or
+        // already-decomposed.
+        let decomposed = text.decomposedStringWithCanonicalMapping
         var result = ""
-        for scalar in text.unicodeScalars {
+        result.reserveCapacity(decomposed.unicodeScalars.count)
+        for scalar in decomposed.unicodeScalars {
+            if scalar.properties.generalCategory == .nonspacingMark {
+                continue
+            }
             if let replacement = Self.mathScriptVariantMap[scalar] {
-                result += replacement
+                result.append(replacement)
             } else {
-                result += String(scalar)
+                result.unicodeScalars.append(scalar)
             }
         }
         return result
@@ -92,6 +115,12 @@ private extension AnchorLookupOptions {
             ("ₖ", "k"), ("ₗ", "l"), ("ₘ", "m"), ("ₙ", "n"), ("ₒ", "o"),
             ("ₚ", "p"), ("ᵣ", "r"), ("ₛ", "s"), ("ₜ", "t"), ("ᵤ", "u"),
             ("ᵥ", "v"), ("ₓ", "x"),
+            ("ₔ", "ə"),  // U+2094 schwa — completes the U+2090..U+209C block
+        ]
+        // Greek subscripts U+1D66..U+1D6A. Common in stats / physics theses
+        // (e.g., regression coefficients, density subscripts).
+        let greekSubscriptLetters = [
+            ("ᵦ", "β"), ("ᵧ", "γ"), ("ᵨ", "ρ"), ("ᵩ", "φ"), ("ᵪ", "χ"),
         ]
         let superscriptLetters = [
             ("ᵃ", "a"), ("ᵇ", "b"), ("ᶜ", "c"), ("ᵈ", "d"), ("ᵉ", "e"),
@@ -109,6 +138,7 @@ private extension AnchorLookupOptions {
             + superscriptDigits
             + scriptSymbols
             + subscriptLetters
+            + greekSubscriptLetters
             + superscriptLetters {
             add(glyph, replacement)
         }

--- a/Tests/OOXMLSwiftTests/Issue90MathScriptAnchorLookupTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue90MathScriptAnchorLookupTests.swift
@@ -14,10 +14,14 @@ final class Issue90MathScriptAnchorLookupTests: XCTestCase {
         )
     }
 
-    func testCanonicalizeMathScriptVariantsPreservesUnsupportedCharacters() {
+    func testCanonicalizeMathScriptVariantsPreservesUnmappedNonMarkCharacters() {
+        // `∴`, `∮`, `Æ` are not in the math-script map and have no NFD
+        // decomposition, so they pass through unchanged. (Note: `≠` is NOT
+        // a good example here because NFD decomposes it to `=` + combining
+        // long solidus overlay, and the canonicalizer strips the overlay.)
         XCTAssertEqual(
-            AnchorLookupOptions.canonicalizeMathScriptVariants("ᾱ ∴ H₀"),
-            "ᾱ ∴ H0"
+            AnchorLookupOptions.canonicalizeMathScriptVariants("Æ ∴ ∮ H₀"),
+            "Æ ∴ ∮ H0"
         )
     }
 
@@ -126,5 +130,153 @@ final class Issue90MathScriptAnchorLookupTests: XCTestCase {
         )
 
         XCTAssertEqual(sss.visibleText, "H0")
+    }
+
+    // MARK: - Combining macron / accent stripping (X̄, ŷ, etc.)
+
+    func testCanonicalizeStripsCombiningMacronOnMathLetters() {
+        // X̄ (NFC: U+0058 + U+0304) → X
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants("X̄ + Ȳ"),
+            "X + Y"
+        )
+    }
+
+    func testCanonicalizeHandlesDecomposedAndPrecomposedAccentsIdentically() {
+        // ŷ precomposed (U+0177) and ŷ decomposed (y + U+0302 hat) must
+        // canonicalize to the same string.
+        let precomposed = "\u{0177}"             // ŷ
+        let decomposed = "y\u{0302}"             // y + combining hat
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants(precomposed),
+            AnchorLookupOptions.canonicalizeMathScriptVariants(decomposed)
+        )
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants(precomposed),
+            "y"
+        )
+    }
+
+    func testMathScriptInsensitiveMatchesXBarAgainstX() {
+        // Issue #90 body explicitly lists X̄ as an anchor pattern. OMML
+        // `MathAccent.visibleText` emits just the base ("X"), so the user-
+        // typed needle X̄ must match the haystack's plain X.
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "the sample mean X is significant")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "X̄",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            0
+        )
+    }
+
+    func testMathScriptInsensitiveMatchesXAgainstXBar() {
+        // Reverse direction: haystack contains the precomposed combining-mark
+        // form, needle is plain ASCII.
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "the sample mean X̄ is significant")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "X",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            0
+        )
+    }
+
+    // MARK: - Greek subscripts (U+1D66..U+1D6A)
+
+    func testCanonicalizeMapsGreekSubscriptsToGreekLetters() {
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants("Σᵦ + Πᵧ + ρᵨ"),
+            "Σβ + Πγ + ρρ"
+        )
+    }
+
+    func testMathScriptInsensitiveMatchesGreekSubscriptVariants() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "regression coefficient Σβ stable")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "Σᵦ",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            0
+        )
+    }
+
+    // MARK: - U+2094 subscript schwa (completes the U+2090..U+209C block)
+
+    func testCanonicalizeMapsSubscriptSchwa() {
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants("aₔb"),
+            "aəb"
+        )
+    }
+
+    // MARK: - Negative cases (over-fold prevention)
+
+    func testMathScriptInsensitiveDoesNotMatchDifferentSubscriptDigits() {
+        // H₂ must NOT match H₃ even with the flag enabled.
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "Hypothesis H₃ stated above")),
+        ]
+
+        XCTAssertNil(
+            doc.findBodyChildContainingText(
+                "H₂",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            )
+        )
+        XCTAssertNil(
+            doc.findBodyChildContainingText(
+                "H2",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            )
+        )
+    }
+
+    func testMathScriptInsensitiveDoesNotConflateGreekAndLatinLetters() {
+        // Greek alpha α (U+03B1) is NOT mapped to ASCII a; canonicalization
+        // leaves it as-is so it does not over-fold to ASCII variables.
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "variable a defined")),
+        ]
+
+        XCTAssertNil(
+            doc.findBodyChildContainingText(
+                "α",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            )
+        )
+    }
+
+    func testMathScriptInsensitiveDoesNotMatchAcrossBoundary() {
+        // Needle "H₀p" requires a literal `p` immediately after the (folded)
+        // subscript zero; haystack "H_0 p" with a space must NOT match.
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "H_0 p stands for posterior")),
+        ]
+
+        XCTAssertNil(
+            doc.findBodyChildContainingText(
+                "H₀p",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            )
+        )
     }
 }

--- a/Tests/OOXMLSwiftTests/Issue90MathScriptAnchorLookupTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue90MathScriptAnchorLookupTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import OOXMLSwift
+
+final class Issue90MathScriptAnchorLookupTests: XCTestCase {
+
+    func testCanonicalizeMathScriptVariantsMapsPinnedGlyphs() {
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants("H₀ + xᵢ = y²"),
+            "H0 + xi = y2"
+        )
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants("A⁽¹⁾ ₊ B₍₂₎"),
+            "A(1) + B(2)"
+        )
+    }
+
+    func testCanonicalizeMathScriptVariantsPreservesUnsupportedCharacters() {
+        XCTAssertEqual(
+            AnchorLookupOptions.canonicalizeMathScriptVariants("ᾱ ∴ H₀"),
+            "ᾱ ∴ H0"
+        )
+    }
+
+    func testDefaultExactModeDoesNotMatchUnicodeSubscriptNeedleAgainstASCIIHaystack() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "H0 is rejected")),
+        ]
+
+        XCTAssertNil(doc.findBodyChildContainingText("H₀"))
+        XCTAssertFalse(WordDocument.bodyChildContainsText(
+            .paragraph(Paragraph(text: "H0 is rejected")),
+            needle: "H₀"
+        ))
+    }
+
+    func testMathScriptInsensitiveMatchesUnicodeSubscriptNeedleAgainstASCIIHaystack() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "H0 is rejected")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "H₀",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            0
+        )
+    }
+
+    func testMathScriptInsensitiveMatchesASCIINeedleAgainstUnicodeSubscriptHaystack() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "H₀ is rejected")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "H0",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            0
+        )
+    }
+
+    func testMathScriptInsensitiveMatchesSubscriptAndSuperscriptLetters() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "xᵢ + y²")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "xi + y2",
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            0
+        )
+    }
+
+    func testNthInstanceCountsNormalizedMatches() {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "H0 first")),
+            .paragraph(Paragraph(text: "H₀ second")),
+        ]
+
+        XCTAssertEqual(
+            doc.findBodyChildContainingText(
+                "H₀",
+                nthInstance: 2,
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            ),
+            1
+        )
+    }
+
+    func testInsertLocationAfterTextAcceptsMathScriptInsensitiveOption() throws {
+        var doc = WordDocument()
+        doc.body.children = [
+            .paragraph(Paragraph(text: "H0 anchor")),
+        ]
+
+        try doc.insertParagraph(
+            Paragraph(text: "inserted"),
+            at: .afterText(
+                "H₀",
+                instance: 1,
+                options: AnchorLookupOptions(mathScriptInsensitive: true)
+            )
+        )
+
+        XCTAssertEqual(doc.body.children.count, 2)
+        guard case .paragraph(let inserted) = doc.body.children[1] else {
+            XCTFail("Expected inserted paragraph at index 1")
+            return
+        }
+        XCTAssertEqual(inserted.runs.first?.text, "inserted")
+    }
+
+    func testMathSubSuperScriptVisibleTextRemainsASCII() {
+        let sss = MathSubSuperScript(
+            base: [MathRun(text: "H")],
+            sub: [MathRun(text: "0")]
+        )
+
+        XCTAssertEqual(sss.visibleText, "H0")
+    }
+}


### PR DESCRIPTION
## Summary
- add `AnchorLookupOptions` for exact-by-default text-anchor lookup
- add math-script canonicalization for Unicode subscript/superscript variants
- thread lookup options through `findBodyChildContainingText`, `bodyChildContainsText`, `tableContainsText`, and `InsertLocation.afterText` / `.beforeText`

## Validation
- `swift test --filter Issue90MathScriptAnchorLookupTests --filter Issue86PublicAnchorLookupTests`

Refs PsychQuant/che-word-mcp#90