### PR TITLE
Harden inline equation insertion

### DIFF
--- a/Sources/OOXMLSwift/Models/Document.swift
+++ b/Sources/OOXMLSwift/Models/Document.swift
@@ -3955,13 +3955,14 @@ extension WordDocument {
     /// per che-word-mcp#67 F2 (inline anchor semantics are ambiguous —
     /// "append OMML run into existing para containing this text" vs
     /// "insert new para before/after the matching para"); other anchors
-    /// throw `InsertLocationError.inlineModeRequiresParagraphIndex` (post-#91;
-    /// pre-#91 abused `.invalidParagraphIndex(-1)` as a sentinel which lied
-    /// about the failure shape).
+    /// throw `InsertLocationError.inlineModeRequiresParagraphIndexForAnchor`
+    /// with the rejected anchor kind (post-#23; pre-#91 abused
+    /// `.invalidParagraphIndex(-1)` as a sentinel which lied about the failure
+    /// shape).
     ///
     /// - Throws: `InsertLocationError` on anchor resolution failure;
-    ///   `InsertLocationError.inlineModeRequiresParagraphIndex` for inline-mode
-    ///   non-`paragraphIndex` anchors;
+    ///   `InsertLocationError.inlineModeRequiresParagraphIndexForAnchor` for
+    ///   inline-mode non-`paragraphIndex` anchors;
     ///   `InsertLocationError.invalidParagraphIndex(idx)` for inline-mode
     ///   `.paragraphIndex(idx)` with out-of-range `idx` (post-#91; pre-#91 this
     ///   silently no-op'd via the deprecated `Int?` overload).
@@ -3973,34 +3974,29 @@ extension WordDocument {
         if !displayMode {
             // che-word-mcp#67 F2: inline equation rejects non-paragraphIndex
             // anchors. che-word-mcp#91 Defect 2: explicit bounds-check before
-            // delegating to legacy `Int?` overload, which silently no-ops on
+            // insertion because the legacy `Int?` overload silently no-ops on
             // out-of-range index (asymmetric vs display mode's throw).
             //
             // che-word-mcp#91 verify F1 (convergent finding from Codex P1 +
             // Devil's Advocate DA-1): bounds-check MUST count only top-level
             // `.paragraph` body children, NOT `getParagraphs().count` which
             // recurses into block-level `.contentControl` (Document.swift:222).
-            // The legacy `Int?` overload's loop at line 4044 below ONLY
-            // enumerates direct top-level paragraphs (no SDT descent), so a
-            // narrower count is what the delegate can actually reach.
+            // Inline insertion enumerates direct top-level paragraphs only (no
+            // SDT descent), so a narrower count is what the operation can
+            // actually reach.
             // Pre-corrective bug: doc shape `[.contentControl(_, [.paragraph])]`
             // has `getParagraphs().count == 1`, so `.paragraphIndex(0)` passed
-            // the guard but the delegate found zero matches and silently
+            // the old guard but the legacy path found zero matches and silently
             // no-op'd — exactly the failure class Defect 2 was meant to fix.
             if case .paragraphIndex(let idx) = location {
-                let topLevelParagraphCount = body.children.reduce(0) { count, child in
-                    if case .paragraph = child { return count + 1 }
-                    return count
-                }
-                guard idx >= 0, idx < topLevelParagraphCount else {
+                guard appendInlineEquationRun(atTopLevelParagraphIndex: idx, latex: latex) else {
                     throw InsertLocationError.invalidParagraphIndex(idx)
                 }
-                insertEquation(at: idx, latex: latex, displayMode: false)
                 return
             }
             // che-word-mcp#91 Defect 1: dedicated error case (was
             // `.invalidParagraphIndex(-1)` sentinel pre-fix).
-            throw InsertLocationError.inlineModeRequiresParagraphIndex
+            throw InsertLocationError.inlineModeRequiresParagraphIndexForAnchor(location.anchorKindName)
         }
 
         // Display mode: build the equation paragraph then route through
@@ -4032,16 +4028,15 @@ extension WordDocument {
     /// for anchor-aware insertion. This Int?-only signature will be removed
     /// in v0.22 (alongside other v0.22 deprecations: `Hyperlink.text` setter,
     /// `Paragraph.commentIds` field).
-    @available(*, deprecated, message: "Use insertEquation(at: InsertLocation, latex:, displayMode:) for anchor-aware insertion. Will be removed in v0.22.")
+    @available(*, deprecated, message: "Use insertEquation(at: InsertLocation, latex:, displayMode:) for anchor-aware insertion. WARNING: legacy inline overload can silently no-op on out-of-range indexes and SDT-nested paragraphs; the new overload throws structured errors. Will be removed in v0.22.")
     public mutating func insertEquation(
         at paragraphIndex: Int? = nil,
         latex: String,
         displayMode: Bool = false
     ) {
-        let equation = MathEquation(latex: latex, displayMode: displayMode)
-
         if displayMode {
             // 獨立區塊公式，建立新段落
+            let equation = MathEquation(latex: latex, displayMode: true)
             var para = Paragraph()
             var run = Run(text: "")
             run.properties.rawXML = equation.toXML()
@@ -4055,25 +4050,43 @@ extension WordDocument {
             }
         } else {
             // 行內公式，加入到現有段落
-            if let idx = paragraphIndex, idx >= 0 && idx < getParagraphs().count {
-                var childIndex = 0
-                for (i, child) in body.children.enumerated() {
-                    if case .paragraph = child {
-                        if childIndex == idx {
-                            var run = Run(text: "")
-                            run.properties.rawXML = equation.toXML()
-                            if case .paragraph(var para) = body.children[i] {
-                                para.runs.append(run)
-                                body.children[i] = .paragraph(para)
-                            }
-                            modifiedParts.insert("word/document.xml")
-                            return
-                        }
-                        childIndex += 1
-                    }
-                }
+            if let idx = paragraphIndex {
+                _ = appendInlineEquationRun(atTopLevelParagraphIndex: idx, latex: latex)
             }
         }
+    }
+
+    /// Append an inline equation run to the Nth top-level body paragraph.
+    ///
+    /// Inline equations intentionally target only direct `.paragraph` body
+    /// children. Block-level SDT descendants are excluded to match the
+    /// post-#91 contract and avoid `getParagraphs()` recursion drift. Returning
+    /// `false` lets the new `InsertLocation` overload throw while the deprecated
+    /// `Int?` overload preserves its legacy no-op behavior (#21/#22).
+    @discardableResult
+    private mutating func appendInlineEquationRun(
+        atTopLevelParagraphIndex paragraphIndex: Int,
+        latex: String
+    ) -> Bool {
+        guard paragraphIndex >= 0 else { return false }
+
+        var childIndex = 0
+        for i in body.children.indices {
+            guard case .paragraph(var para) = body.children[i] else { continue }
+            if childIndex == paragraphIndex {
+                let equation = MathEquation(latex: latex, displayMode: false)
+                let omml = equation.toXML()
+                var run = Run(text: "")
+                run.properties.rawXML = omml
+                run.rawXML = omml
+                para.runs.append(run)
+                body.children[i] = .paragraph(para)
+                modifiedParts.insert("word/document.xml")
+                return true
+            }
+            childIndex += 1
+        }
+        return false
     }
 
     // MARK: - Advanced Paragraph Formatting

--- a/Sources/OOXMLSwift/Models/InsertLocation.swift
+++ b/Sources/OOXMLSwift/Models/InsertLocation.swift
@@ -22,6 +22,24 @@ public enum InsertLocation: Equatable {
     case intoTableCell(tableIndex: Int, row: Int, col: Int)
     case afterText(String, instance: Int)
     case beforeText(String, instance: Int)
+
+    /// Payload-stripped anchor name for diagnostics and structured errors.
+    public var anchorKindName: String {
+        switch self {
+        case .paragraphIndex:
+            return "paragraphIndex"
+        case .afterImageId:
+            return "afterImageId"
+        case .afterTableIndex:
+            return "afterTableIndex"
+        case .intoTableCell:
+            return "intoTableCell"
+        case .afterText:
+            return "afterText"
+        case .beforeText:
+            return "beforeText"
+        }
+    }
 }
 
 /// Error thrown when an `InsertLocation` cannot be resolved in the target document.
@@ -39,6 +57,10 @@ public enum InsertLocationError: Error, Equatable {
     /// anchor kind". This dedicated case lets callers distinguish the two
     /// failures cleanly.
     case inlineModeRequiresParagraphIndex
+    /// Same inline-mode rejection as `inlineModeRequiresParagraphIndex`, with
+    /// payload-stripped context for the actual anchor kind the caller passed.
+    /// The bare case remains for source compatibility with existing switches.
+    case inlineModeRequiresParagraphIndexForAnchor(String)
 }
 
 // MARK: - Document resolution

--- a/Tests/OOXMLSwiftTests/Issue84InsertEquationLocationTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue84InsertEquationLocationTests.swift
@@ -71,8 +71,8 @@ final class Issue84InsertEquationLocationTests: XCTestCase {
 
     /// Spec / che-word-mcp#67 F2 + che-word-mcp#91: inline equation explicitly
     /// rejects non-`paragraphIndex` anchors. `.afterText` in inline mode throws
-    /// the dedicated `InsertLocationError.inlineModeRequiresParagraphIndex`
-    /// case (post-#91; pre-#91 used the misleading `.invalidParagraphIndex(-1)`
+    /// the dedicated `InsertLocationError.inlineModeRequiresParagraphIndexForAnchor`
+    /// case (post-#23; pre-#91 used the misleading `.invalidParagraphIndex(-1)`
     /// sentinel — see `Issue91InlineModeRejectionTests` for full coverage of
     /// all 5 non-paragraphIndex anchor cases).
     func testInlineModeRejectsAfterTextAnchor() throws {
@@ -83,7 +83,7 @@ final class Issue84InsertEquationLocationTests: XCTestCase {
             displayMode: false
         )) { error in
             XCTAssertEqual(error as? InsertLocationError,
-                .inlineModeRequiresParagraphIndex,
+                .inlineModeRequiresParagraphIndexForAnchor("afterText"),
                 "inline mode must reject non-paragraphIndex anchors with the dedicated error case (#91)")
         }
     }

--- a/Tests/OOXMLSwiftTests/Issue91InlineModeRejectionTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue91InlineModeRejectionTests.swift
@@ -20,9 +20,10 @@ import XCTest
 ///    — asymmetric error semantics for one public API.
 ///
 /// Post-fix contract: BOTH cases throw, with the new dedicated
-/// `InsertLocationError.inlineModeRequiresParagraphIndex` for non-paragraphIndex
-/// anchors and the existing `InsertLocationError.invalidParagraphIndex(idx)` for
-/// bad index in inline mode.
+/// `InsertLocationError.inlineModeRequiresParagraphIndexForAnchor(anchor)` for
+/// non-paragraphIndex anchors and the existing
+/// `InsertLocationError.invalidParagraphIndex(idx)` for bad index in inline
+/// mode.
 final class Issue91InlineModeRejectionTests: XCTestCase {
 
     // MARK: - Defect 2: silent no-op on bad inline index
@@ -65,8 +66,8 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
     // MARK: - Defect 1: sentinel misuse for non-paragraphIndex anchors
 
     /// Spec: inline-mode `insertEquation` with `.afterImageId` MUST throw the
-    /// dedicated `inlineModeRequiresParagraphIndex` error, NOT the
-    /// `invalidParagraphIndex(-1)` sentinel.
+    /// dedicated `inlineModeRequiresParagraphIndexForAnchor` error, NOT the
+    /// `invalidParagraphIndex(-1)` sentinel, and carries the rejected anchor.
     func testInlineModeThrowsOnAfterImageId() throws {
         var doc = try buildDocWithThreeParagraphs()
         XCTAssertThrowsError(try doc.insertEquation(
@@ -75,13 +76,13 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
             displayMode: false
         )) { error in
             XCTAssertEqual(error as? InsertLocationError,
-                .inlineModeRequiresParagraphIndex,
+                .inlineModeRequiresParagraphIndexForAnchor("afterImageId"),
                 "inline mode rejection must use the dedicated error case, not invalidParagraphIndex(-1)")
         }
     }
 
     /// Spec: inline-mode `insertEquation` with `.intoTableCell` MUST throw the
-    /// dedicated `inlineModeRequiresParagraphIndex` error.
+    /// dedicated `inlineModeRequiresParagraphIndexForAnchor` error.
     func testInlineModeThrowsOnIntoTableCell() throws {
         var doc = try buildDocWithThreeParagraphs()
         XCTAssertThrowsError(try doc.insertEquation(
@@ -90,12 +91,12 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
             displayMode: false
         )) { error in
             XCTAssertEqual(error as? InsertLocationError,
-                .inlineModeRequiresParagraphIndex)
+                .inlineModeRequiresParagraphIndexForAnchor("intoTableCell"))
         }
     }
 
     /// Spec: inline-mode `insertEquation` with `.afterTableIndex` MUST throw
-    /// the dedicated `inlineModeRequiresParagraphIndex` error.
+    /// the dedicated `inlineModeRequiresParagraphIndexForAnchor` error.
     func testInlineModeThrowsOnAfterTableIndex() throws {
         var doc = try buildDocWithThreeParagraphs()
         XCTAssertThrowsError(try doc.insertEquation(
@@ -104,13 +105,13 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
             displayMode: false
         )) { error in
             XCTAssertEqual(error as? InsertLocationError,
-                .inlineModeRequiresParagraphIndex)
+                .inlineModeRequiresParagraphIndexForAnchor("afterTableIndex"))
         }
     }
 
     /// Spec: inline-mode `insertEquation` with `.beforeText` MUST throw the
-    /// dedicated `inlineModeRequiresParagraphIndex` error (the symmetric
-    /// counterpart to the existing `.afterText` test in
+    /// dedicated `inlineModeRequiresParagraphIndexForAnchor` error (the
+    /// symmetric counterpart to the existing `.afterText` test in
     /// `Issue84InsertEquationLocationTests.testInlineModeRejectsAfterTextAnchor`).
     func testInlineModeThrowsOnBeforeText() throws {
         var doc = try buildDocWithThreeParagraphs()
@@ -120,7 +121,7 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
             displayMode: false
         )) { error in
             XCTAssertEqual(error as? InsertLocationError,
-                .inlineModeRequiresParagraphIndex)
+                .inlineModeRequiresParagraphIndexForAnchor("beforeText"))
         }
     }
 
@@ -204,6 +205,27 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
         ), "valid top-level idx must still succeed post-corrective")
     }
 
+    /// #21 regression guard: valid inline insertion appends directly to the
+    /// target top-level paragraph and exposes the OMML immediately through the
+    /// inserted run's rawXML.
+    func testInlineModeValidParagraphIndexAppendsEquationRun() throws {
+        var doc = try buildDocWithThreeParagraphs()
+
+        try doc.insertEquation(
+            at: .paragraphIndex(1),
+            latex: "x + y",
+            displayMode: false
+        )
+
+        guard case .paragraph(let paragraph) = doc.body.children[1] else {
+            return XCTFail("expected target paragraph")
+        }
+        XCTAssertEqual(paragraph.runs.count, 2)
+        XCTAssertTrue(paragraph.runs[1].rawXML?.contains("x + y") ?? false,
+            "inline equation run should be appended to the target paragraph")
+        XCTAssertTrue(doc.modifiedParts.contains("word/document.xml"))
+    }
+
     /// F6 verify follow-up: empty-doc edge case (`paragraphCount == 0`) +
     /// `.paragraphIndex(0)` inline mode throws `invalidParagraphIndex(0)`.
     func testInlineModeThrowsOnEmptyDocument() throws {
@@ -263,6 +285,23 @@ final class Issue91InlineModeRejectionTests: XCTestCase {
             }
             XCTAssertEqual(rId, "rId-nonexistent")
         }
+    }
+
+    /// #22 regression guard: the deprecated Int? overload cannot throw without
+    /// a source-breaking signature change, so its deprecation warning must
+    /// explicitly document the legacy inline no-op risk.
+    func testDeprecatedIntOverloadWarningDocumentsLegacyNoOpRisk() throws {
+        let documentSource = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/OOXMLSwift/Models/Document.swift")
+        let source = try String(contentsOf: documentSource, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("legacy inline overload can silently no-op"),
+            "deprecated insertEquation Int? overload must warn direct callers about the legacy silent no-op risk")
+        XCTAssertTrue(source.contains("the new overload throws structured errors"),
+            "deprecated warning must point callers to the structured-error InsertLocation overload")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Route inline `InsertLocation` equation insertion through a direct top-level paragraph helper instead of the deprecated `Int?` overload.
- Add anchor-kind context for inline-mode rejection while keeping the legacy bare error case available.
- Expand deprecation warning coverage for the legacy inline overload silent no-op risk.

## Tests
- `swift test --filter 'Issue91InlineModeRejectionTests|Issue84InsertEquationLocationTests'`
- `swift test`

Refs #21, #22, #23