### PR TITLE
fix: updateAllFields recurses bodyChildren for header/footer/footnote/endnote

### DIFF
--- a/Sources/OOXMLSwift/Models/WordDocument+UpdateAllFields.swift
+++ b/Sources/OOXMLSwift/Models/WordDocument+UpdateAllFields.swift
@@ -84,17 +84,36 @@ extension WordDocument {
 
         // Headers — per-header dirty bit. Under isolation, each header gets
         // a fresh counter dict (independent of body and other headers).
+        //
+        // #25 (v0.22.x+): containers iterate `bodyChildren` (canonical storage)
+        // through `walkAndProcessBodyChildForFields`, the same recursive walker
+        // body uses. This picks up SEQ inside header table cells / footer SDT
+        // children / etc. Previously the container loops iterated the legacy
+        // `.paragraphs` flat-view computed property, which silently dropped
+        // `.table` and `.contentControl` BodyChild siblings.
+        //
+        // `isTopLevel: false` for all container walks (matches body-side
+        // semantic at line ~64: SDT/table-internal headings don't reset
+        // chapter counters; same logic applies to container-internal headings).
+        // Each container instance gets a fresh `containerHeadingCount` dict —
+        // headers/footers may have their own outline that must not pollute
+        // body's chapter counter.
         var dirtyHeaderFiles: Set<String> = []
         for i in 0..<headers.count {
             var headerCounters: [String: Int] = isolatePerContainer ? [:] : counters
             var headerLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
+            var containerHeadingCount: [Int: Int] = [:]  // container-local; never feeds body
             var headerDirty = false
-            for j in 0..<headers[i].paragraphs.count {
-                var para = headers[i].paragraphs[j]
-                if processParagraph(&para, counters: &headerCounters, lastResetHeadingCount: &headerLastReset, currentHeadingCount: currentHeadingCount) {
+            for j in 0..<headers[i].bodyChildren.count {
+                if walkAndProcessBodyChildForFields(
+                    &headers[i].bodyChildren[j],
+                    counters: &headerCounters,
+                    lastResetHeadingCount: &headerLastReset,
+                    currentHeadingCount: &containerHeadingCount,
+                    isTopLevel: false
+                ) {
                     headerDirty = true
                 }
-                headers[i].paragraphs[j] = para
             }
             if !isolatePerContainer {
                 counters = headerCounters
@@ -103,18 +122,23 @@ extension WordDocument {
             if headerDirty { dirtyHeaderFiles.insert(headers[i].fileName) }
         }
 
-        // Footers — same isolation pattern as headers.
+        // Footers — same isolation + walker pattern as headers (#25).
         var dirtyFooterFiles: Set<String> = []
         for i in 0..<footers.count {
             var footerCounters: [String: Int] = isolatePerContainer ? [:] : counters
             var footerLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
+            var containerHeadingCount: [Int: Int] = [:]
             var footerDirty = false
-            for j in 0..<footers[i].paragraphs.count {
-                var para = footers[i].paragraphs[j]
-                if processParagraph(&para, counters: &footerCounters, lastResetHeadingCount: &footerLastReset, currentHeadingCount: currentHeadingCount) {
+            for j in 0..<footers[i].bodyChildren.count {
+                if walkAndProcessBodyChildForFields(
+                    &footers[i].bodyChildren[j],
+                    counters: &footerCounters,
+                    lastResetHeadingCount: &footerLastReset,
+                    currentHeadingCount: &containerHeadingCount,
+                    isTopLevel: false
+                ) {
                     footerDirty = true
                 }
-                footers[i].paragraphs[j] = para
             }
             if !isolatePerContainer {
                 counters = footerCounters
@@ -124,16 +148,22 @@ extension WordDocument {
         }
 
         // Footnotes — single container family, isolated as a unit.
+        // #25: walker recursion through bodyChildren (same as headers/footers).
         var footnotesCounters: [String: Int] = isolatePerContainer ? [:] : counters
         var footnotesLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
         var footnotesDirty = false
         for i in 0..<footnotes.footnotes.count {
-            for j in 0..<footnotes.footnotes[i].paragraphs.count {
-                var para = footnotes.footnotes[i].paragraphs[j]
-                if processParagraph(&para, counters: &footnotesCounters, lastResetHeadingCount: &footnotesLastReset, currentHeadingCount: currentHeadingCount) {
+            var containerHeadingCount: [Int: Int] = [:]
+            for j in 0..<footnotes.footnotes[i].bodyChildren.count {
+                if walkAndProcessBodyChildForFields(
+                    &footnotes.footnotes[i].bodyChildren[j],
+                    counters: &footnotesCounters,
+                    lastResetHeadingCount: &footnotesLastReset,
+                    currentHeadingCount: &containerHeadingCount,
+                    isTopLevel: false
+                ) {
                     footnotesDirty = true
                 }
-                footnotes.footnotes[i].paragraphs[j] = para
             }
         }
         if !isolatePerContainer {
@@ -142,16 +172,22 @@ extension WordDocument {
         }
 
         // Endnotes — single container family, isolated as a unit.
+        // #25: walker recursion through bodyChildren.
         var endnotesCounters: [String: Int] = isolatePerContainer ? [:] : counters
         var endnotesLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
         var endnotesDirty = false
         for i in 0..<endnotes.endnotes.count {
-            for j in 0..<endnotes.endnotes[i].paragraphs.count {
-                var para = endnotes.endnotes[i].paragraphs[j]
-                if processParagraph(&para, counters: &endnotesCounters, lastResetHeadingCount: &endnotesLastReset, currentHeadingCount: currentHeadingCount) {
+            var containerHeadingCount: [Int: Int] = [:]
+            for j in 0..<endnotes.endnotes[i].bodyChildren.count {
+                if walkAndProcessBodyChildForFields(
+                    &endnotes.endnotes[i].bodyChildren[j],
+                    counters: &endnotesCounters,
+                    lastResetHeadingCount: &endnotesLastReset,
+                    currentHeadingCount: &containerHeadingCount,
+                    isTopLevel: false
+                ) {
                     endnotesDirty = true
                 }
-                endnotes.endnotes[i].paragraphs[j] = para
             }
         }
         if !isolatePerContainer {

--- a/Sources/OOXMLSwift/Models/WordDocument+UpdateAllFields.swift
+++ b/Sources/OOXMLSwift/Models/WordDocument+UpdateAllFields.swift
@@ -102,7 +102,13 @@ extension WordDocument {
         for i in 0..<headers.count {
             var headerCounters: [String: Int] = isolatePerContainer ? [:] : counters
             var headerLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
-            var containerHeadingCount: [Int: Int] = [:]  // container-local; never feeds body
+            // #25 P1 fix: in shared-counter mode (isolatePerContainer=false), seed with body's
+// current heading count so SEQ resetLevel comparisons (currentCount vs lastReset)
+// don't false-reset. In isolation mode, fresh `[:]` is correct (containers are
+// independent of body's outline). Walker still passes isTopLevel:false for
+// containers, so heading-count never increments here — this seed only matters
+// for the resetLevel comparison inside processParagraph.
+var containerHeadingCount: [Int: Int] = isolatePerContainer ? [:] : currentHeadingCount  // container-local; never feeds body
             var headerDirty = false
             for j in 0..<headers[i].bodyChildren.count {
                 if walkAndProcessBodyChildForFields(
@@ -127,7 +133,13 @@ extension WordDocument {
         for i in 0..<footers.count {
             var footerCounters: [String: Int] = isolatePerContainer ? [:] : counters
             var footerLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
-            var containerHeadingCount: [Int: Int] = [:]
+            // #25 P1 fix: in shared-counter mode (isolatePerContainer=false), seed with body's
+// current heading count so SEQ resetLevel comparisons (currentCount vs lastReset)
+// don't false-reset. In isolation mode, fresh `[:]` is correct (containers are
+// independent of body's outline). Walker still passes isTopLevel:false for
+// containers, so heading-count never increments here — this seed only matters
+// for the resetLevel comparison inside processParagraph.
+var containerHeadingCount: [Int: Int] = isolatePerContainer ? [:] : currentHeadingCount
             var footerDirty = false
             for j in 0..<footers[i].bodyChildren.count {
                 if walkAndProcessBodyChildForFields(
@@ -153,7 +165,13 @@ extension WordDocument {
         var footnotesLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
         var footnotesDirty = false
         for i in 0..<footnotes.footnotes.count {
-            var containerHeadingCount: [Int: Int] = [:]
+            // #25 P1 fix: in shared-counter mode (isolatePerContainer=false), seed with body's
+// current heading count so SEQ resetLevel comparisons (currentCount vs lastReset)
+// don't false-reset. In isolation mode, fresh `[:]` is correct (containers are
+// independent of body's outline). Walker still passes isTopLevel:false for
+// containers, so heading-count never increments here — this seed only matters
+// for the resetLevel comparison inside processParagraph.
+var containerHeadingCount: [Int: Int] = isolatePerContainer ? [:] : currentHeadingCount
             for j in 0..<footnotes.footnotes[i].bodyChildren.count {
                 if walkAndProcessBodyChildForFields(
                     &footnotes.footnotes[i].bodyChildren[j],
@@ -177,7 +195,13 @@ extension WordDocument {
         var endnotesLastReset: [String: Int] = isolatePerContainer ? [:] : lastResetHeadingCount
         var endnotesDirty = false
         for i in 0..<endnotes.endnotes.count {
-            var containerHeadingCount: [Int: Int] = [:]
+            // #25 P1 fix: in shared-counter mode (isolatePerContainer=false), seed with body's
+// current heading count so SEQ resetLevel comparisons (currentCount vs lastReset)
+// don't false-reset. In isolation mode, fresh `[:]` is correct (containers are
+// independent of body's outline). Walker still passes isTopLevel:false for
+// containers, so heading-count never increments here — this seed only matters
+// for the resetLevel comparison inside processParagraph.
+var containerHeadingCount: [Int: Int] = isolatePerContainer ? [:] : currentHeadingCount
             for j in 0..<endnotes.endnotes[i].bodyChildren.count {
                 if walkAndProcessBodyChildForFields(
                     &endnotes.endnotes[i].bodyChildren[j],

--- a/Tests/OOXMLSwiftTests/Issue94UpdateAllFieldsContainerCoverageTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue94UpdateAllFieldsContainerCoverageTests.swift
@@ -227,4 +227,177 @@ final class Issue94UpdateAllFieldsContainerCoverageTests: XCTestCase {
         XCTAssertEqual(cachedResultOfFirstSEQ(in: f3), "3",
             "Trailing top-level Figure must continue counter (3), not reset to 1 by container-nested heading")
     }
+
+    // MARK: - 25.1 SEQ inside header table cell
+
+    /// PsychQuant/ooxml-swift#25 — header SEQ scan must recurse through bodyChildren.
+    /// Pre-#25 fix: header loop iterated `.paragraphs` (computed flat view, drops
+    /// `.table` siblings); SEQ inside header table cell was silently skipped.
+    /// Post-fix: header loop iterates `bodyChildren` through walkAndProcessBodyChildForFields.
+    func testUpdateAllFieldsRecursesIntoHeaderTableCellParagraphs() {
+        var doc = WordDocument()
+
+        let cellPara1 = captionParagraph(identifier: "Figure", initialCached: "1")
+        let cellPara2 = captionParagraph(identifier: "Figure", initialCached: "1")
+
+        let table = Table(rows: [
+            TableRow(cells: [
+                {
+                    var cell = TableCell()
+                    cell.paragraphs = [cellPara1]
+                    return cell
+                }(),
+                {
+                    var cell = TableCell()
+                    cell.paragraphs = [cellPara2]
+                    return cell
+                }()
+            ])
+        ])
+
+        var header = Header(id: "rId-h1")
+        header.bodyChildren = [.table(table)]
+        doc.headers = [header]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Figure": 2],
+            "Header SEQ scan must traverse table cells inside Header.bodyChildren")
+
+        // Verify cached results were rewritten in the header's table cells
+        guard case .table(let updatedTable) = doc.headers[0].bodyChildren[0] else {
+            return XCTFail("expected .table inside header bodyChildren")
+        }
+        let cell1Cached = cachedResultOfFirstSEQ(in: updatedTable.rows[0].cells[0].paragraphs[0])
+        let cell2Cached = cachedResultOfFirstSEQ(in: updatedTable.rows[0].cells[1].paragraphs[0])
+        XCTAssertEqual(cell1Cached, "1", "header table cell 0 SEQ cachedResult should be 1")
+        XCTAssertEqual(cell2Cached, "2", "header table cell 1 SEQ cachedResult should be 2")
+
+        // Dirty-bit propagation: header file marked modified
+        XCTAssertTrue(doc.modifiedParts.contains("word/\(doc.headers[0].fileName)"),
+            "modifiedParts must include the header file when its SEQ fields were updated")
+    }
+
+    // MARK: - 25.2 SEQ inside footer block-level SDT (.contentControl)
+
+    /// PsychQuant/ooxml-swift#25 — footer SEQ scan must recurse into block-level
+    /// SDT children. Pre-fix: footer loop iterated `.paragraphs` (drops
+    /// `.contentControl` siblings); SEQ inside footer SDT was silently skipped.
+    func testUpdateAllFieldsRecursesIntoFooterSDTChildParagraphs() {
+        var doc = WordDocument()
+
+        let innerPara1 = captionParagraph(identifier: "Figure", initialCached: "1")
+        let innerPara2 = captionParagraph(identifier: "Figure", initialCached: "1")
+
+        let sdt = StructuredDocumentTag(id: 200, tag: "issue25-footer-sdt")
+        let cc = ContentControl(sdt: sdt, content: "")
+
+        var footer = Footer(id: "rId-f1")
+        footer.bodyChildren = [
+            .contentControl(cc, children: [
+                .paragraph(innerPara1),
+                .paragraph(innerPara2)
+            ])
+        ]
+        doc.footers = [footer]
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Figure": 2],
+            "Footer SEQ scan must recurse into block-level SDT children")
+
+        guard case .contentControl(_, let updatedChildren) = doc.footers[0].bodyChildren[0] else {
+            return XCTFail("expected .contentControl inside footer bodyChildren")
+        }
+        guard case .paragraph(let p1) = updatedChildren[0],
+              case .paragraph(let p2) = updatedChildren[1] else {
+            return XCTFail("expected paragraphs inside footer SDT")
+        }
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: p1), "1",
+            "footer SDT child[0] SEQ cachedResult should be 1")
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: p2), "2",
+            "footer SDT child[1] SEQ cachedResult should be 2")
+
+        // Dirty-bit propagation: footer file marked modified
+        XCTAssertTrue(doc.modifiedParts.contains("word/\(doc.footers[0].fileName)"),
+            "modifiedParts must include the footer file when its SEQ fields were updated")
+    }
+
+    // MARK: - 25.3 SEQ inside footnote table cell
+
+    /// PsychQuant/ooxml-swift#25 — footnote SEQ scan must recurse through
+    /// bodyChildren so SEQ inside footnote-internal tables is visible.
+    func testUpdateAllFieldsRecursesIntoFootnoteTableCellParagraphs() {
+        var doc = WordDocument()
+
+        let cellPara1 = captionParagraph(identifier: "Source", initialCached: "1")
+        let cellPara2 = captionParagraph(identifier: "Source", initialCached: "1")
+
+        let table = Table(rows: [
+            TableRow(cells: [
+                {
+                    var cell = TableCell()
+                    cell.paragraphs = [cellPara1]
+                    return cell
+                }(),
+                {
+                    var cell = TableCell()
+                    cell.paragraphs = [cellPara2]
+                    return cell
+                }()
+            ])
+        ])
+
+        var footnote = Footnote(id: 1, text: "", paragraphIndex: 0)
+        footnote.bodyChildren = [.table(table)]
+        doc.footnotes = FootnotesCollection(footnotes: [footnote])
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Source": 2],
+            "Footnote SEQ scan must traverse table cells inside Footnote.bodyChildren")
+
+        guard case .table(let updatedTable) = doc.footnotes.footnotes[0].bodyChildren[0] else {
+            return XCTFail("expected .table inside footnote bodyChildren")
+        }
+        let cell1Cached = cachedResultOfFirstSEQ(in: updatedTable.rows[0].cells[0].paragraphs[0])
+        let cell2Cached = cachedResultOfFirstSEQ(in: updatedTable.rows[0].cells[1].paragraphs[0])
+        XCTAssertEqual(cell1Cached, "1", "footnote table cell 0 SEQ cachedResult should be 1")
+        XCTAssertEqual(cell2Cached, "2", "footnote table cell 1 SEQ cachedResult should be 2")
+
+        // Dirty-bit propagation: footnotes.xml marked modified
+        XCTAssertTrue(doc.modifiedParts.contains("word/footnotes.xml"),
+            "modifiedParts must include word/footnotes.xml when footnote SEQ fields were updated")
+    }
+
+    // MARK: - 25.4 SEQ inside endnote container
+
+    /// PsychQuant/ooxml-swift#25 — endnote SEQ scan must recurse through
+    /// bodyChildren so SEQ inside endnote-internal tables / SDTs is visible.
+    func testUpdateAllFieldsRecursesIntoEndnoteContainerSEQ() {
+        var doc = WordDocument()
+
+        let cellPara = captionParagraph(identifier: "Source", initialCached: "1")
+
+        let table = Table(rows: [
+            TableRow(cells: [
+                {
+                    var cell = TableCell()
+                    cell.paragraphs = [cellPara]
+                    return cell
+                }()
+            ])
+        ])
+
+        var endnote = Endnote(id: 1, text: "", paragraphIndex: 0)
+        endnote.bodyChildren = [.table(table)]
+        doc.endnotes = EndnotesCollection(endnotes: [endnote])
+
+        let result = doc.updateAllFields()
+        XCTAssertEqual(result, ["Source": 1],
+            "Endnote SEQ scan must traverse table cells inside Endnote.bodyChildren")
+
+        guard case .table(let updatedTable) = doc.endnotes.endnotes[0].bodyChildren[0] else {
+            return XCTFail("expected .table inside endnote bodyChildren")
+        }
+        let cellCached = cachedResultOfFirstSEQ(in: updatedTable.rows[0].cells[0].paragraphs[0])
+        XCTAssertEqual(cellCached, "1", "endnote table cell SEQ cachedResult should be 1")
+    }
 }

--- a/Tests/OOXMLSwiftTests/Issue94UpdateAllFieldsContainerCoverageTests.swift
+++ b/Tests/OOXMLSwiftTests/Issue94UpdateAllFieldsContainerCoverageTests.swift
@@ -400,4 +400,52 @@ final class Issue94UpdateAllFieldsContainerCoverageTests: XCTestCase {
         let cellCached = cachedResultOfFirstSEQ(in: updatedTable.rows[0].cells[0].paragraphs[0])
         XCTAssertEqual(cellCached, "1", "endnote table cell SEQ cachedResult should be 1")
     }
+
+    // MARK: - 25.5 Container SEQ with resetLevel must not false-reset (P1 regression)
+
+    /// PsychQuant/ooxml-swift#25 verify P1 finding: pre-fix-commit, containers got
+    /// `containerHeadingCount = [:]` (always 0) while `lastResetHeadingCount`
+    /// inherited body's accumulated state. processParagraph's resetLevel logic
+    /// compares currentCount[level] vs lastReset[level] — `0 != N` triggered a
+    /// false reset, breaking SEQ chain into containers under shared-counter mode.
+    ///
+    /// Repro from Codex's blind verify: body Heading 1 + 2x Figure(\s 1), then
+    /// header Figure(\s 1) — pre-fix returned cached "1" (false-reset to start);
+    /// post-fix returns "3" (continues body counter). The 4 prior tests all use
+    /// `resetLevel: nil` so the resetLevel codepath was never exercised.
+    func testUpdateAllFieldsHeaderSEQWithResetLevelChainsBodyCounter() {
+        var doc = WordDocument()
+
+        // Body: Heading 1 + 2x Figure with resetLevel=1
+        let h1 = headingParagraph(level: 1, text: "Chapter 1")
+        let bodyFig1 = captionParagraph(identifier: "Figure", resetLevel: 1, initialCached: "1")
+        let bodyFig2 = captionParagraph(identifier: "Figure", resetLevel: 1, initialCached: "1")
+        doc.body.children = [
+            .paragraph(h1),
+            .paragraph(bodyFig1),
+            .paragraph(bodyFig2)
+        ]
+
+        // Header: 1x Figure with resetLevel=1 (same identifier as body)
+        let headerFig = captionParagraph(identifier: "Figure", resetLevel: 1, initialCached: "1")
+        var header = Header(id: "rId-h1")
+        header.bodyChildren = [.paragraph(headerFig)]
+        doc.headers = [header]
+
+        // Default isolatePerContainer=false — header should chain body's counter.
+        let result = doc.updateAllFields()
+
+        // Pre-fix: result == ["Figure": 1] (header false-reset to start)
+        // Post-fix: result == ["Figure": 3] (header continues body's counter)
+        XCTAssertEqual(result, ["Figure": 3],
+            "Header SEQ with resetLevel=1 must chain body's accumulated counter when " +
+            "isolatePerContainer=false. Pre-fix bug: containerHeadingCount=[:] " +
+            "+ inherited lastResetHeadingCount caused false reset.")
+
+        guard case .paragraph(let updatedHeaderPara) = doc.headers[0].bodyChildren[0] else {
+            return XCTFail("expected .paragraph in header bodyChildren")
+        }
+        XCTAssertEqual(cachedResultOfFirstSEQ(in: updatedHeaderPara), "3",
+            "Header Figure SEQ cachedResult must be 3 (continues body's counter), not 1 (false-reset)")
+    }
 }


### PR DESCRIPTION
Refs #25

## Summary

`updateAllFields` v0.21.9 fixed body-side SEQ traversal (#94) but the 4 sister container families (Headers, Footers, Footnotes, Endnotes) were left iterating `.paragraphs` flat view — silently dropping `.table` and `.contentControl` siblings. SEQ inside header table cells / footer SDT children / footnote tables / endnote tables was invisible to the scan.

This PR brings the 4 containers to byte-equivalent recursion semantics by routing each through the existing `walkAndProcessBodyChildForFields` walker.

## Approach

- **Reuse existing walker** (Option A from #25 issue body) — no new walker added; #28 (BodyChildVisitor protocol) is the eventual cleanup.
- **Switch iteration source** from `.paragraphs[j]` (computed flat view) to `.bodyChildren[j]` (canonical storage; already `public var` on all 4 containers since v0.19.5+).
- **`isTopLevel: false`** for all container walks (matches body-side semantic: SDT/table-internal headings don't reset chapter counters).
- **Container-local fresh `currentHeadingCount: [Int: Int] = [:]`** per container instance — never shared with body's outline counter.
- **Preserves**: per-container counter isolation, `dirtyHeaderFiles` / `dirtyFooterFiles` set semantics, `footnotesDirty` / `endnotesDirty` single-bit tracking, `modifiedParts` propagation.

## Tests

4 new tests in `Issue94UpdateAllFieldsContainerCoverageTests.swift` (MARK 25.1–25.4):

| Test | Fixture | Assertion |
|---|---|---|
| `testUpdateAllFieldsRecursesIntoHeaderTableCellParagraphs` | SEQ in `Header.bodyChildren[0]` table cell | `result["Figure"] == 2`, cachedResults rewritten, `modifiedParts` contains `word/header1.xml` |
| `testUpdateAllFieldsRecursesIntoFooterSDTChildParagraphs` | SEQ in `Footer.bodyChildren[0]` `.contentControl` child | `result["Figure"] == 2`, cachedResults rewritten, `modifiedParts` contains `word/footer1.xml` |
| `testUpdateAllFieldsRecursesIntoFootnoteTableCellParagraphs` | SEQ in `footnotes.footnotes[0].bodyChildren[0]` table | `result["Source"] == 2`, cachedResults rewritten, `modifiedParts` contains `word/footnotes.xml` |
| `testUpdateAllFieldsRecursesIntoEndnoteContainerSEQ` | SEQ in `endnotes.endnotes[0].bodyChildren[0]` table | `result["Source"] == 1`, cachedResult rewritten |

All reuse existing `captionParagraph(...)` and `cachedResultOfFirstSEQ(...)` helpers.

## Test Results

- `swift build`: clean (pre-existing deprecation warnings only)
- `swift test --filter Issue94UpdateAllFieldsContainerCoverageTests`: **8/8 pass** (4 existing + 4 new)
- `swift test --filter UpdateAllFields`: **26/26 pass** (Tests / Coverage / CounterIsolation / HeaderPreservation / Issue94 families)
- `swift test` (full): **856 pass, 0 failures, 1 pre-existing skip**

## Plan + Diagnosis

- Diagnosis: https://github.com/PsychQuant/ooxml-swift/issues/25#issuecomment-4367526000
- Implementation Plan (Plan tier approved via EnterPlanMode/ExitPlanMode): https://github.com/PsychQuant/ooxml-swift/issues/25#issuecomment-4367544931

## Tangential follow-ups (filed mid-plan, not blocking)

- #45 — TableCell shape: no `bodyChildren`, block-level SDT siblings not modelable (refactor)
- #46 — Footnote.swift contains both Footnote and Endnote structs (refactor / good-first-issue)
- #47 — `isolatePerContainer` flag undocumented in references/ (docs)

## Checklist

- [x] Diagnose
- [x] Plan tier approval (EnterPlanMode/ExitPlanMode)
- [x] Implement (1 commit, atomic impl + tests)
- [x] Build clean, full test suite green (856/856)
- [ ] Verify (`/idd-verify #25` 6-AI ensemble)
- [ ] **Pending**: human review of this PR + `/idd-close #25` after merge

---

🤖 Generated by /idd-implement on PR path. **Do NOT add 'Closes #25'** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.