### PR TITLE
docs: update insertEquation deprecation message to v1.0 removal target (#58)

### DIFF
--- a/Sources/OOXMLSwift/Models/Document.swift
+++ b/Sources/OOXMLSwift/Models/Document.swift
@@ -4030,9 +4030,10 @@ extension WordDocument {
     ///
     /// **Deprecated in v0.21.5** — use the `InsertLocation` overload above
     /// for anchor-aware insertion. This Int?-only signature will be removed
-    /// in v0.22 (alongside other v0.22 deprecations: `Hyperlink.text` setter,
-    /// `Paragraph.commentIds` field).
-    @available(*, deprecated, message: "Use insertEquation(at: InsertLocation, latex:, displayMode:) for anchor-aware insertion. Will be removed in v0.22.")
+    /// in ooxml-swift 1.0 (alongside other 1.0 deprecations: `MathEquation`
+    /// flat-string OMML emit, `Hyperlink.text` setter, `Paragraph.commentIds`
+    /// field).
+    @available(*, deprecated, message: "Use insertEquation(at: InsertLocation, latex:, displayMode:) for anchor-aware insertion. Will be removed in ooxml-swift 1.0.")
     public mutating func insertEquation(
         at paragraphIndex: Int? = nil,
         latex: String,


### PR DESCRIPTION
## Summary

Refs #58

The legacy `insertEquation(at: Int? = nil, ...)` overload's deprecation message says "Will be removed in v0.22" but main is now at v0.24.0 — message has been factually stale for 3 minor releases.

Update both the `@available` message and the doc-comment block to reference "ooxml-swift 1.0" — matching `MathEquation`'s deprecation message at `Field.swift:301`.

## Verification

- [x] `swift build` clean
- [x] `swift test` 871 tests, 0 failures, 1 pre-existing skip
- [x] No functional change — pure docstring fix