### PR TITLE
chain: verify-PASS for #10 (absorbed by PsychQuant/macdoc#99)

### DIFF
--- a/docs/chain-10-cross-repo-verify-2026-05-25.md
+++ b/docs/chain-10-cross-repo-verify-2026-05-25.md
@@ -1,0 +1,9 @@
+# Cross-repo Chain: ooxml-swift#10 Verify (2026-05-25)
+
+`/idd-all-chain --cwd /Users/che/Developer/macdoc/packages/ooxml-swift #10` executed against ooxml-swift repo.
+
+Issue ooxml-swift#10 (paragraph-mutator index semantics divergence) was absorbed by PsychQuant/macdoc#99 (ooxml-edit-isomorphism-foundation) — Edit-type contract resolves the divergence at type level (OOXMLEdit positional, WordEdit stable-ID, lower() bridge).
+
+Chain mechanism: Phase 0 pre-flight ✓, Phase 0.5 cluster branch ✓, Phase 2 verify-PASS ✓, Phase 3 cluster PR (this commit).
+
+Refs PsychQuant/macdoc#99 PsychQuant/macdoc#106


### PR DESCRIPTION
Refs #10

## Summary

Cross-repo `/idd-all-chain` execution for #10. Issue absorbed by PsychQuant/macdoc#99 Edit-type contract; no ooxml-swift-side independent work needed.

See `docs/chain-10-cross-repo-verify-2026-05-25.md` for chain mechanism record.

Refs #10 PsychQuant/macdoc#99