### PR TITLE
feat(OpLog/Phase 2c): insertParagraphAfter/Before + removeParagraph + setRunFormat-bold

### DIFF
--- a/Sources/OOXMLSwift/OpLog/ElementID.swift
+++ b/Sources/OOXMLSwift/OpLog/ElementID.swift
@@ -60,4 +60,20 @@ public struct ElementID: Equatable, Hashable, Sendable, Codable {
     public init(rawString: String) {
         self.raw = rawString
     }
+
+    /// Extracts the library-generated UUID if this ElementID's `raw` string is
+    /// in `"lib:<UUID>"` form (i.e., was constructed via `init(libraryUUID:)`
+    /// or matched a node whose `stableID` was nil and used `libraryUUID`
+    /// fallback). Returns `nil` for native-ID forms (`"w14:paraId=..."`,
+    /// `"w:id=..."`, etc.) — those have no UUID to extract.
+    ///
+    /// Used by OperationReducer Phase 2c when materializing tree-mutating ops:
+    /// the new node's `libraryUUID` is derived deterministically from the
+    /// entry's `opID`, so the Reducer needs to construct an ElementID with
+    /// that UUID and address the new node via it.
+    public var libraryUUID: UUID? {
+        guard raw.hasPrefix("lib:") else { return nil }
+        let uuidString = String(raw.dropFirst("lib:".count))
+        return UUID(uuidString: uuidString)
+    }
 }

--- a/Sources/OOXMLSwift/OpLog/OperationReducer.swift
+++ b/Sources/OOXMLSwift/OpLog/OperationReducer.swift
@@ -221,10 +221,45 @@ public enum OperationReducer {
             newP.libraryUUID = entry.opID
             parent.children.insert(newP, at: idx + 1)
 
-        // Phase 2b unsupported op kinds — Phase 2c implements these incrementally.
-        case .insertParagraphBefore, .removeParagraph,
-             .insertTable, .removeTable, .setCellText,
-             .insertRun, .setRunFormat,
+        case .insertParagraphBefore(let before, let payload):
+            guard let (parent, idx) = findParentAndIndex(targetID: before, in: tree.root) else {
+                throw ReducerError.elementNotFound(opID: entry.opID, elementID: before)
+            }
+            let newP = makeParagraph(text: payload.text, styleId: payload.styleId)
+            newP.libraryUUID = entry.opID
+            parent.children.insert(newP, at: idx)
+
+        case .removeParagraph(let target):
+            guard let (parent, idx) = findParentAndIndex(targetID: target, in: tree.root) else {
+                throw ReducerError.elementNotFound(opID: entry.opID, elementID: target)
+            }
+            parent.children.remove(at: idx)
+            // MVP: removed paragraph's cross-part refs (comments, footnotes,
+            // bookmarks pointing TO this paragraph) are left dangling. A
+            // follow-up should add orphan-collection — file issue if needed.
+
+        case .setRunFormat(let target, let format):
+            // MVP: bold only (sufficient for OOXMLEdit.setBold). Other
+            // fields throw malformedOp — add italic/underline/fontSize/color
+            // when corresponding OOXMLEdit cases appear.
+            if format.italic != nil || format.underline != nil
+               || format.fontSizeHalfPoints != nil || format.color != nil {
+                throw ReducerError.malformedOp(
+                    opID: entry.opID,
+                    reason: "Phase 2c MVP supports RunFormatPayload.bold only — italic/underline/fontSizeHalfPoints/color pending"
+                )
+            }
+            guard let node = findNode(elementID: target, in: tree) else {
+                throw ReducerError.elementNotFound(opID: entry.opID, elementID: target)
+            }
+            if let bold = format.bold {
+                try setOrRemoveBold(runNode: node, value: bold)
+            }
+            // bold == nil → no-op (leave unchanged)
+
+        // Phase 2c remaining unsupported op kinds — implemented incrementally.
+        case .insertTable, .removeTable, .setCellText,
+             .insertRun,
              .insertBookmark, .insertComment,
              .redo,
              .insertNode, .removeNode, .updateAttribute, .moveNode:
@@ -258,6 +293,38 @@ public enum OperationReducer {
             }
         }
         return nil
+    }
+
+    /// Sets or removes `<w:b/>` inside a `<w:r>`'s `<w:rPr>` to reflect the
+    /// boolean bold value. `value == true` ensures `<w:b/>` is present;
+    /// `value == false` removes any existing `<w:b/>` element (relies on
+    /// style inheritance for the "not bold" default).
+    ///
+    /// Creates `<w:rPr>` if needed; removes empty `<w:rPr>` if it becomes
+    /// childless after the operation (keeps tree minimal).
+    private static func setOrRemoveBold(runNode: XmlNode, value: Bool) throws {
+        // Find or create <w:rPr>. Per OOXML schema, rPr is the FIRST child of <w:r>.
+        let rPr: XmlNode
+        if let existing = runNode.children.first(where: { $0.kind == .element && $0.localName == "rPr" }) {
+            rPr = existing
+        } else if value {
+            rPr = XmlNode.element(prefix: "w", localName: "rPr")
+            runNode.children = [rPr] + runNode.children
+        } else {
+            // value is false and there's no rPr — already not-bold via inheritance.
+            return
+        }
+        // Remove existing <w:b>.
+        rPr.children = rPr.children.filter { !($0.kind == .element && $0.localName == "b") }
+        // Add <w:b/> if value is true.
+        if value {
+            let b = XmlNode.element(prefix: "w", localName: "b")
+            rPr.children.append(b)
+        }
+        // If rPr is now empty, remove it (tree minimization).
+        if rPr.children.isEmpty {
+            runNode.children = runNode.children.filter { $0 !== rPr }
+        }
     }
 
     /// Constructs a fresh `<w:p>` element with one `<w:r><w:t>text</w:t></w:r>`

--- a/Sources/OOXMLSwift/OpLog/OperationReducer.swift
+++ b/Sources/OOXMLSwift/OpLog/OperationReducer.swift
@@ -210,8 +210,19 @@ public enum OperationReducer {
             // Should not reach here — undo is interpreted in applyOrInterpret.
             return
 
-        // Phase 2b unsupported op kinds — Phase 2c implements these.
-        case .insertParagraphAfter, .insertParagraphBefore, .removeParagraph,
+        case .insertParagraphAfter(let after, let payload):
+            // Find target + parent + position.
+            guard let (parent, idx) = findParentAndIndex(targetID: after, in: tree.root) else {
+                throw ReducerError.elementNotFound(opID: entry.opID, elementID: after)
+            }
+            let newP = makeParagraph(text: payload.text, styleId: payload.styleId)
+            // Deterministic ID derivation: new paragraph's libraryUUID == entry.opID.
+            // This makes log replay produce the same tree every time.
+            newP.libraryUUID = entry.opID
+            parent.children.insert(newP, at: idx + 1)
+
+        // Phase 2b unsupported op kinds — Phase 2c implements these incrementally.
+        case .insertParagraphBefore, .removeParagraph,
              .insertTable, .removeTable, .setCellText,
              .insertRun, .setRunFormat,
              .insertBookmark, .insertComment,
@@ -222,6 +233,55 @@ public enum OperationReducer {
                 reason: "Phase 2c implements this op"
             )
         }
+    }
+
+    // MARK: - Phase 2c helpers
+
+    /// Walks the tree from `root` looking for a node whose ElementID matches
+    /// `targetID`. Returns the target's parent and its index in
+    /// `parent.children`. Returns `nil` if target not found.
+    ///
+    /// Root cannot be the target (root has no parent) — if `targetID` matches
+    /// `root` itself, returns nil. That's a limitation: ops can't target the
+    /// document root, only nested elements (which is fine for OOXML — body
+    /// children and below are the only meaningful targets).
+    internal static func findParentAndIndex(
+        targetID: ElementID,
+        in root: XmlNode
+    ) -> (XmlNode, Int)? {
+        for (idx, child) in root.children.enumerated() {
+            if let id = ElementID(node: child), id == targetID {
+                return (root, idx)
+            }
+            if let found = findParentAndIndex(targetID: targetID, in: child) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    /// Constructs a fresh `<w:p>` element with one `<w:r><w:t>text</w:t></w:r>`
+    /// child run. Optional `<w:pPr><w:pStyle w:val="styleId"/></w:pPr>` is
+    /// prepended when `styleId` is non-nil and non-empty.
+    ///
+    /// The returned paragraph has NO libraryUUID — caller is responsible for
+    /// assigning one (typically `entry.opID` for deterministic-replay).
+    /// Child Run is anonymous (no libraryUUID) — future Operations addressing
+    /// the run must use path-based addressing (entry.opID + child path index).
+    internal static func makeParagraph(text: String, styleId: String?) -> XmlNode {
+        let textNode = XmlNode.text(text)
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+
+        var children: [XmlNode] = []
+        if let styleId = styleId, !styleId.isEmpty {
+            let pStyle = XmlNode.element(prefix: "w", localName: "pStyle")
+            pStyle.setAttribute(prefix: "w", localName: "val", value: styleId)
+            let pPr = XmlNode.element(prefix: "w", localName: "pPr", children: [pStyle])
+            children.append(pPr)
+        }
+        children.append(wr)
+        return XmlNode.element(prefix: "w", localName: "p", children: children)
     }
 
     /// Applies the INVERSE of an entry's op (used by `undo` and by `.undo`

--- a/Tests/OOXMLSwiftTests/OperationReducerPhase2cTests.swift
+++ b/Tests/OOXMLSwiftTests/OperationReducerPhase2cTests.swift
@@ -1,0 +1,221 @@
+// OperationReducerPhase2cTests.swift
+// OpLog Phase 2c — tree-mutating Operation cases in OperationReducer.
+// PsychQuant/ooxml-swift#71
+//
+// Implements the cases macdoc#105 (Edit algebra) needs end-to-end:
+//   1. insertParagraphAfter  (this file — pioneer case)
+//   2. insertParagraphBefore (symmetric — added once 1 is green)
+//   3. removeParagraph
+//   4. setRunFormat
+//   5. insertNode + updateAttribute (composite primitives)
+//
+// Each case validates:
+//   (a) tree mutated correctly per Operation semantics
+//   (b) ID stability — existing nodes' ElementIDs unchanged
+//   (c) New node ID is deterministic from entry.opID (so log replay is stable)
+
+import XCTest
+@testable import OOXMLSwift
+
+final class OperationReducerPhase2cTests: XCTestCase {
+
+    // MARK: - Test helpers
+
+    /// Builds a synthesized WordDocument body with N paragraphs, each
+    /// containing one text run with the given text. Returns the tree +
+    /// each paragraph's ElementID for addressability in tests.
+    private func makeBodyWithParagraphs(_ texts: [String]) -> (XmlTree, [ElementID]) {
+        var paraIDs: [ElementID] = []
+        var paragraphs: [XmlNode] = []
+
+        for text in texts {
+            let paraUUID = UUID()
+            paraIDs.append(ElementID(libraryUUID: paraUUID))
+
+            let textNode = XmlNode.text(text)
+            let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+            let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+            let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+            wp.libraryUUID = paraUUID
+            paragraphs.append(wp)
+        }
+
+        let body = XmlNode.element(prefix: "w", localName: "body", children: paragraphs)
+        let doc = XmlNode.element(prefix: "w", localName: "document", children: [body])
+        return (XmlTree.synthesized(root: doc), paraIDs)
+    }
+
+    /// Walks tree, returns text content of all <w:t> descendants in document order.
+    private func extractAllText(_ tree: XmlTree) -> [String] {
+        var result: [String] = []
+        func walk(_ node: XmlNode) {
+            if node.kind == .element && node.localName == "t" {
+                for child in node.children where child.kind == .text {
+                    result.append(child.textContent)
+                }
+            }
+            for child in node.children {
+                walk(child)
+            }
+        }
+        walk(tree.root)
+        return result
+    }
+
+    /// Returns the libraryUUIDs of all <w:p> descendants in document order.
+    private func extractParagraphIDs(_ tree: XmlTree) -> [UUID?] {
+        var result: [UUID?] = []
+        func walk(_ node: XmlNode) {
+            if node.kind == .element && node.localName == "p" {
+                result.append(node.libraryUUID)
+            }
+            for child in node.children {
+                walk(child)
+            }
+        }
+        walk(tree.root)
+        return result
+    }
+
+    // MARK: - insertParagraphAfter
+
+    func testInsertParagraphAfterAppendsToBody() throws {
+        // GIVEN body with one paragraph "first"
+        let (base, paraIDs) = makeBodyWithParagraphs(["first"])
+        XCTAssertEqual(extractAllText(base), ["first"])
+
+        // WHEN insertParagraphAfter with content "second"
+        var log = OperationLog()
+        log.append(
+            .insertParagraphAfter(
+                after: paraIDs[0],
+                paragraph: ParagraphPayload(text: "second", styleId: nil)
+            ),
+            source: .swift
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+
+        // THEN body contains 2 paragraphs in order: first, second
+        XCTAssertEqual(extractAllText(result), ["first", "second"],
+                       "New paragraph appears AFTER target in document order")
+    }
+
+    func testInsertParagraphAfterPreservesExistingParagraphID() throws {
+        let (base, paraIDs) = makeBodyWithParagraphs(["first"])
+        let originalFirstID = paraIDs[0].libraryUUID
+
+        var log = OperationLog()
+        log.append(
+            .insertParagraphAfter(
+                after: paraIDs[0],
+                paragraph: ParagraphPayload(text: "second", styleId: nil)
+            ),
+            source: .swift
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        let resultIDs = extractParagraphIDs(result)
+
+        XCTAssertEqual(resultIDs.count, 2, "Two paragraphs in result")
+        XCTAssertEqual(resultIDs[0], originalFirstID,
+                       "Existing paragraph's libraryUUID unchanged")
+        XCTAssertNotNil(resultIDs[1], "New paragraph has a libraryUUID")
+    }
+
+    func testInsertParagraphAfterNewParagraphIDDerivesFromOpID() throws {
+        // Determinism check: new paragraph's libraryUUID == entry.opID.
+        // This makes log replay produce the same tree every time.
+        let (base, paraIDs) = makeBodyWithParagraphs(["first"])
+
+        let determinedOpID = UUID()
+        var log = OperationLog()
+        log.append(
+            .insertParagraphAfter(
+                after: paraIDs[0],
+                paragraph: ParagraphPayload(text: "second", styleId: nil)
+            ),
+            source: .swift,
+            opID: determinedOpID
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        let resultIDs = extractParagraphIDs(result)
+
+        XCTAssertEqual(resultIDs[1], determinedOpID,
+                       "New paragraph's libraryUUID == entry.opID (deterministic replay)")
+    }
+
+    func testInsertParagraphAfterReplayIsIdempotent() throws {
+        // Same log applied twice → same tree shape (modulo deep-clone).
+        let (base, paraIDs) = makeBodyWithParagraphs(["first"])
+
+        var log = OperationLog()
+        log.append(
+            .insertParagraphAfter(
+                after: paraIDs[0],
+                paragraph: ParagraphPayload(text: "second", styleId: nil)
+            ),
+            source: .swift,
+            opID: UUID()  // fixed opID
+        )
+
+        let first = try OperationReducer.materialize(log: log, base: base)
+        let second = try OperationReducer.materialize(log: log, base: base)
+
+        XCTAssertEqual(extractAllText(first), extractAllText(second),
+                       "Replaying same log produces same text content")
+        XCTAssertEqual(extractParagraphIDs(first), extractParagraphIDs(second),
+                       "Replaying same log produces same paragraph IDs")
+    }
+
+    func testInsertParagraphAfterTargetNotFoundThrows() {
+        let (base, _) = makeBodyWithParagraphs(["first"])
+
+        // Reference a non-existent ElementID
+        var log = OperationLog()
+        log.append(
+            .insertParagraphAfter(
+                after: ElementID(libraryUUID: UUID()),  // never inserted into base
+                paragraph: ParagraphPayload(text: "second", styleId: nil)
+            ),
+            source: .swift
+        )
+
+        XCTAssertThrowsError(try OperationReducer.materialize(log: log, base: base)) { error in
+            guard case ReducerError.elementNotFound = error else {
+                XCTFail("Expected .elementNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testInsertParagraphAfterMultipleCases() throws {
+        // Sequence: start with [a], insert "b" after a → [a, b]; insert "c" after b → [a, b, c].
+        let (base, paraIDs) = makeBodyWithParagraphs(["a"])
+        let aID = paraIDs[0]
+
+        let opIDB = UUID()
+        let opIDC = UUID()
+
+        var log = OperationLog()
+        log.append(
+            .insertParagraphAfter(after: aID, paragraph: ParagraphPayload(text: "b", styleId: nil)),
+            source: .swift,
+            opID: opIDB
+        )
+        // After the first op, new paragraph "b"'s libraryUUID == opIDB.
+        log.append(
+            .insertParagraphAfter(
+                after: ElementID(libraryUUID: opIDB),
+                paragraph: ParagraphPayload(text: "c", styleId: nil)
+            ),
+            source: .swift,
+            opID: opIDC
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        XCTAssertEqual(extractAllText(result), ["a", "b", "c"],
+                       "Sequential insertParagraphAfter chains via deterministic new IDs")
+    }
+}

--- a/Tests/OOXMLSwiftTests/OperationReducerPhase2cTests.swift
+++ b/Tests/OOXMLSwiftTests/OperationReducerPhase2cTests.swift
@@ -190,6 +190,214 @@ final class OperationReducerPhase2cTests: XCTestCase {
         }
     }
 
+    // MARK: - insertParagraphBefore (symmetric)
+
+    func testInsertParagraphBeforePrependsBeforeTarget() throws {
+        let (base, paraIDs) = makeBodyWithParagraphs(["second"])
+
+        var log = OperationLog()
+        log.append(
+            .insertParagraphBefore(
+                before: paraIDs[0],
+                paragraph: ParagraphPayload(text: "first", styleId: nil)
+            ),
+            source: .swift
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        XCTAssertEqual(extractAllText(result), ["first", "second"],
+                       "New paragraph appears BEFORE target in document order")
+    }
+
+    func testInsertParagraphBeforeNewParagraphIDDerivesFromOpID() throws {
+        let (base, paraIDs) = makeBodyWithParagraphs(["second"])
+        let determinedOpID = UUID()
+
+        var log = OperationLog()
+        log.append(
+            .insertParagraphBefore(
+                before: paraIDs[0],
+                paragraph: ParagraphPayload(text: "first", styleId: nil)
+            ),
+            source: .swift,
+            opID: determinedOpID
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        let resultIDs = extractParagraphIDs(result)
+        XCTAssertEqual(resultIDs[0], determinedOpID,
+                       "New paragraph (inserted before) has libraryUUID == entry.opID")
+    }
+
+    func testInsertParagraphBeforeTargetNotFoundThrows() {
+        let (base, _) = makeBodyWithParagraphs(["one"])
+
+        var log = OperationLog()
+        log.append(
+            .insertParagraphBefore(
+                before: ElementID(libraryUUID: UUID()),
+                paragraph: ParagraphPayload(text: "before", styleId: nil)
+            ),
+            source: .swift
+        )
+
+        XCTAssertThrowsError(try OperationReducer.materialize(log: log, base: base)) { error in
+            guard case ReducerError.elementNotFound = error else {
+                XCTFail("Expected .elementNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - setRunFormat (bold only — sufficient for OOXMLEdit.setBold)
+
+    private func makeBodyWithSingleRun(text: String) -> (XmlTree, ElementID) {
+        let runUUID = UUID()
+        let textNode = XmlNode.text(text)
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+        wr.libraryUUID = runUUID
+        let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+        let body = XmlNode.element(prefix: "w", localName: "body", children: [wp])
+        let doc = XmlNode.element(prefix: "w", localName: "document", children: [body])
+        return (XmlTree.synthesized(root: doc), ElementID(libraryUUID: runUUID))
+    }
+
+    /// Walks tree finding the run with given ElementID, returns true if it has
+    /// <w:rPr><w:b/></w:rPr> (i.e., bold is on).
+    private func runIsBold(_ tree: XmlTree, runID: ElementID) -> Bool {
+        guard let run = OperationReducer.findNode(elementID: runID, in: tree) else {
+            return false
+        }
+        guard let rPr = run.children.first(where: { $0.kind == .element && $0.localName == "rPr" }) else {
+            return false
+        }
+        return rPr.children.contains { $0.kind == .element && $0.localName == "b" }
+    }
+
+    func testSetRunFormatBoldTrueAddsBoldElement() throws {
+        let (base, runID) = makeBodyWithSingleRun(text: "hello")
+        XCTAssertFalse(runIsBold(base, runID: runID), "Baseline: run is not bold")
+
+        var log = OperationLog()
+        log.append(
+            .setRunFormat(target: runID, format: RunFormatPayload(bold: true)),
+            source: .swift
+        )
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        XCTAssertTrue(runIsBold(result, runID: runID),
+                      "After setRunFormat(bold: true), run has <w:b/> in rPr")
+    }
+
+    func testSetRunFormatBoldFalseRemovesBoldElement() throws {
+        // First add bold, then remove it via a second op.
+        let (base, runID) = makeBodyWithSingleRun(text: "hello")
+
+        var log = OperationLog()
+        log.append(.setRunFormat(target: runID, format: RunFormatPayload(bold: true)), source: .swift)
+        log.append(.setRunFormat(target: runID, format: RunFormatPayload(bold: false)), source: .swift)
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        XCTAssertFalse(runIsBold(result, runID: runID),
+                       "After setRunFormat(bold: false), <w:b/> removed from rPr")
+    }
+
+    func testSetRunFormatBoldNilLeavesUnchanged() throws {
+        // First set bold true. Then send payload with all nil (no-op).
+        let (base, runID) = makeBodyWithSingleRun(text: "hello")
+
+        var log = OperationLog()
+        log.append(.setRunFormat(target: runID, format: RunFormatPayload(bold: true)), source: .swift)
+        log.append(.setRunFormat(target: runID, format: RunFormatPayload()), source: .swift)
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        XCTAssertTrue(runIsBold(result, runID: runID),
+                      "After setRunFormat with all-nil payload, bold stays true (nil = leave unchanged)")
+    }
+
+    func testSetRunFormatTargetNotFoundThrows() {
+        let (base, _) = makeBodyWithSingleRun(text: "hello")
+
+        var log = OperationLog()
+        log.append(
+            .setRunFormat(target: ElementID(libraryUUID: UUID()),
+                          format: RunFormatPayload(bold: true)),
+            source: .swift
+        )
+
+        XCTAssertThrowsError(try OperationReducer.materialize(log: log, base: base)) { error in
+            guard case ReducerError.elementNotFound = error else {
+                XCTFail("Expected .elementNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testSetRunFormatUnsupportedFieldThrows() {
+        // MVP: only bold is implemented. italic/underline/fontSize/color
+        // throw malformedOp("Phase 2c MVP supports bold only ...").
+        let (base, runID) = makeBodyWithSingleRun(text: "hello")
+
+        var log = OperationLog()
+        log.append(
+            .setRunFormat(target: runID, format: RunFormatPayload(italic: true)),
+            source: .swift
+        )
+
+        XCTAssertThrowsError(try OperationReducer.materialize(log: log, base: base)) { error in
+            guard case ReducerError.malformedOp = error else {
+                XCTFail("Expected .malformedOp for unsupported italic field, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - removeParagraph
+
+    func testRemoveParagraphRemovesTargetFromBody() throws {
+        let (base, paraIDs) = makeBodyWithParagraphs(["a", "b", "c"])
+
+        var log = OperationLog()
+        log.append(.removeParagraph(id: paraIDs[1]), source: .swift)  // remove "b"
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        XCTAssertEqual(extractAllText(result), ["a", "c"],
+                       "Target paragraph removed; siblings preserved in order")
+    }
+
+    func testRemoveParagraphPreservesSiblingIDs() throws {
+        let (base, paraIDs) = makeBodyWithParagraphs(["a", "b", "c"])
+        let aID = paraIDs[0].libraryUUID
+        let cID = paraIDs[2].libraryUUID
+
+        var log = OperationLog()
+        log.append(.removeParagraph(id: paraIDs[1]), source: .swift)
+
+        let result = try OperationReducer.materialize(log: log, base: base)
+        let resultIDs = extractParagraphIDs(result)
+
+        XCTAssertEqual(resultIDs.count, 2)
+        XCTAssertEqual(resultIDs[0], aID, "Sibling 'a' libraryUUID unchanged")
+        XCTAssertEqual(resultIDs[1], cID, "Sibling 'c' libraryUUID unchanged")
+    }
+
+    func testRemoveParagraphTargetNotFoundThrows() {
+        let (base, _) = makeBodyWithParagraphs(["a"])
+
+        var log = OperationLog()
+        log.append(.removeParagraph(id: ElementID(libraryUUID: UUID())), source: .swift)
+
+        XCTAssertThrowsError(try OperationReducer.materialize(log: log, base: base)) { error in
+            guard case ReducerError.elementNotFound = error else {
+                XCTFail("Expected .elementNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - insertParagraphAfter additional (multiple-case chaining)
+
     func testInsertParagraphAfterMultipleCases() throws {
         // Sequence: start with [a], insert "b" after a → [a, b]; insert "c" after b → [a, b, c].
         let (base, paraIDs) = makeBodyWithParagraphs(["a"])


### PR DESCRIPTION
## Summary

First slice of OpLog Phase 2c — implements 4 of 14 currently-throwing tree-mutating Operation cases in `OperationReducer.apply(entry:to:)`. Unblocks the macdoc#105 Edit-algebra end-to-end tests.

Closes the critical-path subset of #71 (insertParagraphAfter, insertParagraphBefore, removeParagraph, setRunFormat-bold). Remaining 10 cases tracked in #71 as follow-up scope.

## Cases shipped

| Case | Reducer behavior | Tests |
|---|---|---|
| `insertParagraphAfter(after:, paragraph:)` | Find target's parent + index; insert new `<w:p>` at idx+1 | 6 |
| `insertParagraphBefore(before:, paragraph:)` | Symmetric to After (insert at idx) | 3 |
| `removeParagraph(id:)` | Find target's parent + index; remove from `parent.children` | 3 |
| `setRunFormat(target:, format:)` — **bold MVP** | Set/remove `<w:b/>` in target Run's `<w:rPr>`. Other RunFormatPayload fields (italic/underline/fontSize/color) throw `malformedOp` until corresponding OOXMLEdit cases appear | 5 |

17 new tests in `Tests/OOXMLSwiftTests/OperationReducerPhase2cTests.swift`. Full suite: 1003 tests pass, 0 failures.

## Key design decisions

### 1. Deterministic ID derivation: new paragraph's `libraryUUID == entry.opID`

Critical for event-sourcing: replaying the same log must produce the same tree (otherwise log isn't source of truth). The convention pinned here is the simplest one that preserves replay determinism — same opID → same new paragraph ID.

Consequence: callers who need to address a Reducer-created paragraph in a subsequent Operation must use `ElementID(libraryUUID: priorOpID)`. Demonstrated in `testInsertParagraphAfterMultipleCases` where the second insertParagraph chains by addressing the first's output.

### 2. Child Runs of new paragraphs are anonymous (no libraryUUID)

Inside `makeParagraph(text:, styleId:)`, the new `<w:r>` doesn't get its own libraryUUID. Future Operations that need to address that Run must use path-based addressing (entry.opID + child path). Matches how `DocxReader` treats parsed Runs (most don't get libraryUUIDs unless they carry a native OOXML stable ID).

If a future use case needs Run addressability, file a follow-up issue rather than expanding this PR's scope.

### 3. `removeParagraph` leaves cross-part refs dangling (MVP)

Removing a paragraph that has incoming comment / footnote / bookmark refs from other parts leaves those refs as orphans. A clean orphan-collection step would walk all other parts and clean up references — deferred to a follow-up since no current OOXMLEdit case removes paragraphs with external refs.

### 4. `setRunFormat` MVP scope: bold only

Other RunFormatPayload fields throw `ReducerError.malformedOp` with a clear "Phase 2c MVP supports bold only" message. Sufficient for `OOXMLEdit.setBold` (the only OOXMLEdit case that lowers to setRunFormat). Add italic/underline/fontSizeHalfPoints/color when corresponding OOXMLEdit cases appear.

### 5. New `ElementID.libraryUUID` accessor

Extracts UUID from raw if format is `"lib:<UUID>"`. Returns nil for native-ID forms. Used by the Reducer to address newly-created nodes via the deterministic-from-opID convention, and by tests.

## New internal helpers

- `OperationReducer.findParentAndIndex(targetID:, in root:)` — walks tree, returns `(parent, indexOfChild)`. Reused by insertParagraphAfter/Before and removeParagraph. Linear-time; future ID-index could speed it up.
- `OperationReducer.makeParagraph(text:, styleId:)` — constructs fresh `<w:p>` with one `<w:r><w:t>text</w:t></w:r>` + optional `<w:pPr><w:pStyle/></w:pPr>`.
- `OperationReducer.setOrRemoveBold(runNode:, value:)` — manipulates `<w:rPr><w:b/></w:rPr>`. Creates `<w:rPr>` if needed; removes empty `<w:rPr>` after operation (tree minimization).

## Remaining scope (tracked in #71)

| Priority | Case | Notes |
|---|---|---|
| HIGH (needed for macdoc#105 §5) | `insertNode` + `updateAttribute` | Composite primitives for `OOXMLEdit.insertHyperlink`. `insertNode` needs XML-fragment parser strategy (current `XmlTreeReader` expects complete documents). |
| MEDIUM | `removeNode` / `moveNode` | Generic primitives, low usage |
| MEDIUM | `setRunFormat` italic/underline/fontSize/color | Add when corresponding OOXMLEdit case appears |
| LOW | `insertTable` / `removeTable` / `setCellText` | Table-level — no current OOXMLEdit lowering |
| LOW | `insertRun` | No current OOXMLEdit lowering |
| LOW | `insertBookmark` / `insertComment` | Multi-part operations (touch document.xml + comments.xml + rels) |
| LOW | `redo` + extended `applyInverse` for new ops | Undo coverage for tree-mutating ops |

## Test plan

- [x] `OperationReducerPhase2cTests` — 17 new tests, all green
- [x] Full ooxml-swift suite — 1003 pass, 0 failures
- [ ] macdoc#105 e2e tests verified locally (on a downstream branch that merges this PR)
- [ ] Follow-up: real `.docx` fixture test once `WordDocument+Apply.swift` multi-part scoping fix lands

## Background

Discovered 2026-05-31 during macdoc#105 §3 implementation. Foundation macdoc#99 shipped 9 ADRs but assumed Reducer support was already in place; reality is the Reducer was scoped to Phase 2b only. macdoc#105 design.md Decision 6 captures the errata. This PR closes the critical-path subset.

Refs #71
