### PR TITLE
feat(EditAlgebra): Edit protocol + OOXMLEdit/WordEdit enums + WordDocument.apply + e2e tests

### DIFF
--- a/Sources/OOXMLSwift/EditAlgebra/Edit.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/Edit.swift
@@ -1,0 +1,82 @@
+// Edit.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// Edit protocol is the public surface for type-level edits over WordDocument.
+// Backing runtime is the OpLog mechanism shipped in v0.31.x (Operation +
+// OperationLog + OperationReducer), NOT the older applyOverlay/markDirty.
+//
+// Per foundation design.md ADR-002:
+//   "PRs that introduce new Edit cases SHALL attach a commutative diagram
+//    + commute proof."
+// See docs/edit-algebra-cd-discipline.md and openspec/changes/ooxml-edit-isomorphism-foundation/design.md
+// § ADR-002 Worked Examples.
+
+import Foundation
+
+// MARK: - Edit protocol
+
+/// The public surface for type-level edits over a WordDocument.
+///
+/// Conformers are typically `OOXMLEdit` (syntactic layer — addresses OOXML
+/// elements by ElementID) and `WordEdit` (semantic layer — addresses
+/// Word-UI verbs like Cmd-B). `WordEdit.lower()` returns a `[OOXMLEdit]`
+/// translation; `OOXMLEdit.lower()` is identity.
+///
+/// `apply(to:)` returns a new WordDocument (immutable apply — input unchanged)
+/// per foundation `ooxml-edit-algebra` Requirement "Edit Apply Surface on
+/// Document".
+public protocol Edit {
+    /// Applies the edit to a WordDocument, returning a new WordDocument with
+    /// the edit's Operations applied. Throws `EditError` on validation failures
+    /// (path resolution, preserve-violation defensive check, operation log
+    /// failures).
+    ///
+    /// The input `document` is NEVER mutated — the returned WordDocument is
+    /// a fresh value with the edit applied.
+    func apply(to document: WordDocument) throws -> WordDocument
+
+    /// Returns the syntactic-layer translation of this edit. For OOXMLEdit
+    /// cases this returns `[self]` (identity). For WordEdit cases this
+    /// returns the corresponding `[OOXMLEdit]` decomposition, possibly with
+    /// multiple elements when the WordEdit semantics cross structural
+    /// boundaries (e.g., applyBold on a range spanning two paragraphs lowers
+    /// to two `OOXMLEdit.setBold` calls).
+    ///
+    /// `lower()` is total: every WordEdit case MUST return a non-empty list.
+    /// If a WordEdit case has no defined translation, file an ooxml-swift
+    /// issue rather than returning `[]`.
+    func lower() -> [OOXMLEdit]
+}
+
+// MARK: - EditError
+
+/// Errors thrown by `Edit.apply(to:)` and downstream Operation execution.
+///
+/// `pathNotFound` — Edit's target ElementID does not resolve in the input
+/// WordDocument. Caller should re-check the ElementID source (typed view
+/// lookup, prior WordRange resolution, etc.).
+///
+/// `preserveViolation` — Edit's Operations resulted in a c14n-form change
+/// to a part OUTSIDE the Edit's declared target. This is a defensive check
+/// against buggy Edit implementations that accidentally modify unmodified
+/// subtrees (per foundation `ooxml-edit-algebra` Requirement
+/// "Canonical-Identity Round-Trip Contract"). The `expected` and `actual`
+/// fields carry c14n digests for debugging.
+///
+/// `unsupportedOperation` — Edit's target element type doesn't support the
+/// operation (e.g., setBold on a non-Run element). The String carries a
+/// human-readable description for diagnostics.
+///
+/// `notImplemented` — Stub case for in-progress Edit cases (used during
+/// scaffold development; production code should never throw this).
+///
+/// `operationLogFailure` — Internal OperationReducer.materialize threw an
+/// error. The underlying string is the localized description of the
+/// reducer error for debugging.
+public enum EditError: Error, Equatable, Sendable {
+    case pathNotFound(ElementID)
+    case preserveViolation(part: String, expected: String, actual: String)
+    case unsupportedOperation(String)
+    case notImplemented(String)
+    case operationLogFailure(underlying: String)
+}

--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
@@ -20,11 +20,26 @@ extension OOXMLEdit {
     /// 1:1 for simple cases (insertParagraph, setBold, removeParagraph);
     /// composite for `insertHyperlink` (returns 2 Operations atomically).
     ///
-    /// Stub in §1 scaffold — per-case implementation lands in §3-§6 of #105
-    /// tasks. Throws `EditError.notImplemented` for unimplemented cases.
+    /// §3 (this commit): insertParagraph + insertParagraphBefore implemented.
+    /// §4-§6 (pending): setBold, insertHyperlink, removeParagraph.
     public func operations() throws -> [Operation] {
-        throw EditError.notImplemented(
-            "OOXMLEdit.operations() per-case mapping pending — see #105 tasks §3-§6"
-        )
+        switch self {
+        case .insertParagraph(let after, let content, let styleId):
+            return [.insertParagraphAfter(
+                after: after,
+                paragraph: ParagraphPayload(text: content, styleId: styleId)
+            )]
+
+        case .insertParagraphBefore(let before, let content, let styleId):
+            return [.insertParagraphBefore(
+                before: before,
+                paragraph: ParagraphPayload(text: content, styleId: styleId)
+            )]
+
+        case .setBold, .insertHyperlink, .removeParagraph:
+            throw EditError.notImplemented(
+                "OOXMLEdit.operations() for \(self) — see #105 tasks §4-§6"
+            )
+        }
     }
 }

--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
@@ -42,9 +42,12 @@ extension OOXMLEdit {
                 format: RunFormatPayload(bold: value)
             )]
 
-        case .insertHyperlink, .removeParagraph:
+        case .removeParagraph(let target):
+            return [.removeParagraph(id: target)]
+
+        case .insertHyperlink:
             throw EditError.notImplemented(
-                "OOXMLEdit.operations() for \(self) — see #105 tasks §5-§6"
+                "OOXMLEdit.operations() for \(self) — see #105 tasks §5 (composite design pending user checkpoint)"
             )
         }
     }

--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
@@ -36,9 +36,15 @@ extension OOXMLEdit {
                 paragraph: ParagraphPayload(text: content, styleId: styleId)
             )]
 
-        case .setBold, .insertHyperlink, .removeParagraph:
+        case .setBold(let target, let value):
+            return [.setRunFormat(
+                target: target,
+                format: RunFormatPayload(bold: value)
+            )]
+
+        case .insertHyperlink, .removeParagraph:
             throw EditError.notImplemented(
-                "OOXMLEdit.operations() for \(self) — see #105 tasks §4-§6"
+                "OOXMLEdit.operations() for \(self) — see #105 tasks §5-§6"
             )
         }
     }

--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
@@ -1,0 +1,30 @@
+// OOXMLEdit+Operation.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// Per design.md Decision 1, each `OOXMLEdit` case maps to one or more
+// `Operation` enum cases. This extension is the authoritative location of
+// that mapping. §3-§6 of #105 tasks fill it in case-by-case.
+//
+// Mapping table (canonical, per design.md):
+//   OOXMLEdit.insertParagraph(after:content:styleId:) → Operation.insertParagraphAfter
+//   OOXMLEdit.insertParagraphBefore(before:content:styleId:) → Operation.insertParagraphBefore
+//   OOXMLEdit.setBold(target:value:) → Operation.setRunFormat
+//   OOXMLEdit.insertHyperlink(target:href:displayText:) → [Operation.insertNode, Operation.updateAttribute]  (composite atomic)
+//   OOXMLEdit.removeParagraph(target:) → Operation.removeParagraph
+
+import Foundation
+
+extension OOXMLEdit {
+    /// Emits the `[Operation]` log entries this Edit case translates to.
+    ///
+    /// 1:1 for simple cases (insertParagraph, setBold, removeParagraph);
+    /// composite for `insertHyperlink` (returns 2 Operations atomically).
+    ///
+    /// Stub in §1 scaffold — per-case implementation lands in §3-§6 of #105
+    /// tasks. Throws `EditError.notImplemented` for unimplemented cases.
+    public func operations() throws -> [Operation] {
+        throw EditError.notImplemented(
+            "OOXMLEdit.operations() per-case mapping pending — see #105 tasks §3-§6"
+        )
+    }
+}

--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit.swift
@@ -1,0 +1,96 @@
+// OOXMLEdit.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// OOXMLEdit is the syntactic-layer Edit enum. Each case maps to one or more
+// `Operation` enum cases (see OOXMLEdit+Operation.swift for the mapping
+// table). Case names follow OOXML schema-element naming (foundation ADR-005).
+//
+// 5 canonical cases in this Phase 2 ship:
+//   - insertParagraph(after:content:styleId:)
+//   - insertParagraphBefore(before:content:styleId:)
+//   - setBold(target:value:)
+//   - insertHyperlink(target:href:displayText:)
+//   - removeParagraph(target:)
+//
+// Apply routes through Operation + OperationLog + OperationReducer (NOT
+// the older applyOverlay/markDirty per foundation #105 design.md Decision 3).
+
+import Foundation
+
+// MARK: - OOXMLEdit
+
+/// Syntactic-layer Edit — addresses OOXML elements by `ElementID` and emits
+/// `Operation` log entries.
+///
+/// Each case 1:1 or 1:N maps to `Operation` enum cases per the mapping table
+/// in `openspec/changes/ooxml-edit-algebra-implementation/design.md`
+/// Decision 1. The mapping is the public contract that makes property tests
+/// possible and lets callers switch between OOXMLEdit (Edit-typed) and
+/// Operation (log-entry-typed) when convenient.
+public enum OOXMLEdit: Edit, Equatable, Sendable {
+    /// Insert a new paragraph after the specified anchor paragraph.
+    ///
+    /// - `after`: ElementID of the existing paragraph to insert AFTER
+    /// - `content`: text content of the new paragraph
+    /// - `styleId`: optional style ID reference (e.g., "Heading1"); `nil` for default
+    ///
+    /// Maps to `Operation.insertParagraphAfter(after:paragraph:)` with
+    /// `ParagraphPayload(text: content, styleId: styleId)`.
+    case insertParagraph(after: ElementID, content: String, styleId: String?)
+
+    /// Insert a new paragraph before the specified anchor paragraph.
+    ///
+    /// Positional variant of `.insertParagraph(after:)`. Maps to
+    /// `Operation.insertParagraphBefore(before:paragraph:)`.
+    case insertParagraphBefore(before: ElementID, content: String, styleId: String?)
+
+    /// Toggle bold formatting on the specified Run element.
+    ///
+    /// - `target`: ElementID of the Run (must resolve to a `<w:r>` element)
+    /// - `value`: `true` sets `<w:b/>`, `false` removes it (or sets `<w:b w:val="false"/>`
+    ///   per OOXML spec — implementation choice in §4.1)
+    ///
+    /// Maps to `Operation.setRunFormat(target:format:)` with
+    /// `RunFormatPayload(bold: value, ...)`.
+    ///
+    /// Throws `EditError.unsupportedOperation` if target is not a Run.
+    case setBold(target: ElementID, value: Bool)
+
+    /// Insert a hyperlink wrapping the specified target element.
+    ///
+    /// - `target`: ElementID of the element to wrap in `<w:hyperlink>` (typically a Run)
+    /// - `href`: URL the hyperlink points to
+    /// - `displayText`: optional override for displayed text; `nil` uses target's existing text
+    ///
+    /// Composite operation: emits BOTH `Operation.insertNode` (for the
+    /// `<w:hyperlink>` element in document.xml) AND `Operation.updateAttribute`
+    /// (for the new Relationship entry in `_rels/document.xml.rels`).
+    /// Atomic at Edit level — throws `EditError.preserveViolation` if either
+    /// sub-operation cannot apply, with NO partial state in the result.
+    case insertHyperlink(target: ElementID, href: URL, displayText: String?)
+
+    /// Remove the specified paragraph from the document body.
+    ///
+    /// - `target`: ElementID of the paragraph to remove
+    ///
+    /// Maps to `Operation.removeParagraph(id:)`. Body-children indices shift
+    /// after removal; sibling elements remain c14n-equal to their input form
+    /// (canonical-identity invariant per foundation Requirement).
+    case removeParagraph(target: ElementID)
+
+    // MARK: - Edit protocol conformance
+
+    /// Apply this Edit to the WordDocument, routing through Operation + OperationLog +
+    /// OperationReducer. Stub implementation in §1 scaffold — full apply
+    /// wiring lands in §2 (Document.apply public API).
+    public func apply(to document: WordDocument) throws -> WordDocument {
+        throw EditError.notImplemented("OOXMLEdit.apply requires Document.apply(_:) wiring (§2 of #105 tasks)")
+    }
+
+    /// Returns `[self]` — OOXMLEdit is already the syntactic layer; lower()
+    /// is identity. WordEdit cases override this with semantic→syntactic
+    /// translations (see WordEdit.swift).
+    public func lower() -> [OOXMLEdit] {
+        [self]
+    }
+}

--- a/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
@@ -38,6 +38,20 @@ extension WordDocument {
         //    Each OOXMLEdit emits 1+ Operations via the mapping table in
         //    OOXMLEdit+Operation.swift (per design.md Decision 1).
         let ooxmlEdits = edit.lower()
+
+        // Defensive: detect stub Edits that silently lower to []. OOXMLEdit's
+        // lower() always returns [self] (identity), so empty here means a
+        // non-OOXMLEdit (typically a stub WordEdit case) returned []. Without
+        // this check, doc.apply(stubWordEdit) would return the input doc
+        // unchanged — a silent no-op that masks the unimplemented case. §7
+        // of macdoc#105 ships WordEdit.lower() per-case implementations; this
+        // guard becomes dormant once real cases return non-empty [OOXMLEdit].
+        if ooxmlEdits.isEmpty && !(edit is OOXMLEdit) {
+            throw EditError.notImplemented(
+                "Edit of type \(type(of: edit)) returned empty lower() — likely a stub case. Per-case WordEdit.lower() implementations land in §7 of PsychQuant/macdoc#105."
+            )
+        }
+
         var newOps: [Operation] = []
         for ooxmlEdit in ooxmlEdits {
             // OOXMLEdit.operations() may throw EditError.notImplemented for

--- a/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
@@ -1,0 +1,113 @@
+// WordDocument+Apply.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// Public apply API per design.md Decision 3 (Option A: WordDocument owns log).
+// Routes Edit → OOXMLEdit → Operation → OperationLog → OperationReducer.materialize.
+//
+// CURRENT LIMITATION (§2 scaffold): typed views (body/styles/etc.) are NOT
+// re-synced from new xmlTrees after apply. xmlTrees and operationLog ARE
+// correctly updated. End-to-end tests (§3+) inspect xmlTrees directly for
+// canonical-identity assertions. Typed-view re-sync lands in a follow-up
+// task once all OOXMLEdit case implementations exist.
+
+import Foundation
+
+extension WordDocument {
+
+    /// Apply an Edit to this document, returning a new WordDocument with the
+    /// edit's emitted Operations appended to the log + affected XmlTrees
+    /// re-materialized.
+    ///
+    /// Per foundation `ooxml-edit-algebra` Requirement "Edit Apply Surface on
+    /// Document" + this change's design.md Decision 3:
+    /// - Immutable apply (input `self` never mutated)
+    /// - Routes through Operation + OperationLog + OperationReducer (NOT
+    ///   applyOverlay/markDirty)
+    /// - Throws `EditError.pathNotFound` when target ElementID doesn't resolve
+    /// - Throws `EditError.preserveViolation` when defensive check fires
+    /// - Wraps OperationReducer errors as `EditError.operationLogFailure`
+    ///
+    /// **§2 scaffold limitation**: typed views (body/styles/headers/etc.)
+    /// are NOT re-synced from new xmlTrees after apply. xmlTrees +
+    /// operationLog ARE correct. For end-to-end tests, inspect xmlTrees
+    /// directly via `result.xmlTrees["word/document.xml"]`. Typed-view
+    /// re-sync is a follow-up sub-task.
+    public func apply(_ edit: any Edit) throws -> WordDocument {
+        // 1. Lower edit → OOXMLEdit chain → Operations
+        //    WordEdit.lower() returns [OOXMLEdit]; OOXMLEdit.lower() returns [self].
+        //    Each OOXMLEdit emits 1+ Operations via the mapping table in
+        //    OOXMLEdit+Operation.swift (per design.md Decision 1).
+        let ooxmlEdits = edit.lower()
+        var newOps: [Operation] = []
+        for ooxmlEdit in ooxmlEdits {
+            // OOXMLEdit.operations() may throw EditError.notImplemented for
+            // stub cases (§1 scaffold) or EditError.unsupportedOperation for
+            // type-mismatch (e.g., setBold on non-Run target).
+            let ops = try ooxmlEdit.operations()
+            newOps.append(contentsOf: ops)
+        }
+
+        // 2. Build accumulated log = old log + new ops
+        //    OperationLog enforces append-only semantics; we copy + extend.
+        var newLog = self.operationLog
+        for op in newOps {
+            newLog.append(op, source: .swift)
+        }
+
+        // 3. Materialize affected XmlTrees from current trees + new ops
+        //
+        //    Strategy: build a temp log containing ONLY the new ops, then
+        //    replay against current trees. The persistent log (newLog above)
+        //    accumulates full history for audit/JSONL export; the temp log
+        //    is the materialize input for incremental update.
+        //
+        //    Alternative considered: replay full newLog against original
+        //    base trees. Rejected — WordDocument doesn't retain base trees
+        //    after first apply, so this would require an additional field.
+        var tempLog = OperationLog()
+        for op in newOps {
+            tempLog.append(op, source: .swift)
+        }
+
+        var newTrees = self.xmlTrees
+        // For §2 scaffold simplicity: materialize ALL trees against tempLog.
+        // OperationReducer.materialize is a no-op for trees that no operation
+        // touches (the reducer's per-op apply skips unaffected nodes).
+        // Performance follow-up (§10.2 benchmark) will introduce per-part
+        // selective replay if needed.
+        for (partPath, currentTree) in newTrees {
+            do {
+                let materialized = try OperationReducer.materialize(
+                    log: tempLog,
+                    base: currentTree
+                )
+                newTrees[partPath] = materialized
+            } catch {
+                throw EditError.operationLogFailure(
+                    underlying: "OperationReducer.materialize failed on part '\(partPath)': \(error.localizedDescription)"
+                )
+            }
+        }
+
+        // 4. Construct new WordDocument with updated log + trees
+        //    Typed views (body/styles/etc.) carried over from self — STALE
+        //    relative to new xmlTrees. See limitation comment above.
+        var newDocument = self
+        newDocument.operationLog = newLog
+        newDocument.xmlTrees = newTrees
+        return newDocument
+    }
+
+    /// Apply a sequence of Edits in order, folding each result into the next
+    /// apply. Equivalent to chaining individual `apply` calls.
+    ///
+    /// Per spec.md Requirement "Document.apply Public Method" — sequence
+    /// variant for callers iterating over an edit script.
+    public func apply<S: Sequence>(_ edits: S) throws -> WordDocument where S.Element == any Edit {
+        var current = self
+        for edit in edits {
+            current = try current.apply(edit)
+        }
+        return current
+    }
+}

--- a/Sources/OOXMLSwift/EditAlgebra/WordEdit.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordEdit.swift
@@ -1,0 +1,117 @@
+// WordEdit.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// WordEdit is the semantic-layer Edit enum — case names follow Word UI verbs
+// (foundation ADR-005 + ADR-006: Word UI behavior as ground truth).
+//
+// 3 canonical cases in this Phase 2 ship:
+//   - applyBold(range:)              ↔ Word UI: select + Cmd-B
+//   - applyLink(range:url:)          ↔ Word UI: select + Insert→Hyperlink
+//   - applyInsertParagraph(after:content:) ↔ Word UI: position cursor + Enter + type
+//
+// `lower()` translates each WordEdit case to a `[OOXMLEdit]` decomposition.
+// Range-crossing-paragraph cases produce N-element lists (one OOXMLEdit per
+// affected paragraph), per foundation ADR-002 Worked Example 4.
+//
+// Naturality invariant (tested in NaturalityTests):
+//   (WordEdit.a ∘ WordEdit.b).lower() == WordEdit.a.lower() ∘ WordEdit.b.lower()
+
+import Foundation
+
+// MARK: - WordRange
+
+/// Identifies a contiguous range of text within a WordDocument by start/end
+/// Run ElementIDs and character offsets within those Runs.
+///
+/// Range validity is scoped to the WordDocument instance the range was
+/// resolved against — IDs may become stale if the document is mutated
+/// between range creation and `lower()`. `lower()` throws
+/// `EditError.pathNotFound` if either ID doesn't resolve.
+public struct WordRange: Equatable, Sendable {
+    /// ElementID of the first Run containing the start of the range.
+    public let startRun: ElementID
+
+    /// Character offset within `startRun`'s text. 0 means "before the first
+    /// character"; `startRun.text.count` means "after the last character".
+    public let startOffset: Int
+
+    /// ElementID of the last Run containing the end of the range. May equal
+    /// `startRun` for single-Run ranges.
+    public let endRun: ElementID
+
+    /// Character offset within `endRun`'s text. Semantics same as `startOffset`.
+    public let endOffset: Int
+
+    public init(startRun: ElementID, startOffset: Int, endRun: ElementID, endOffset: Int) {
+        self.startRun = startRun
+        self.startOffset = startOffset
+        self.endRun = endRun
+        self.endOffset = endOffset
+    }
+}
+
+// MARK: - ParagraphRef
+
+/// Stable identifier for a paragraph within a WordDocument. Resolves to an
+/// `ElementID` at `lower()` time.
+///
+/// Phase 2 implementation: thin wrapper over `ElementID`; future versions may
+/// support paragraph-by-text-search or paragraph-by-style-and-position
+/// addressing.
+public struct ParagraphRef: Equatable, Sendable {
+    public let elementID: ElementID
+
+    public init(_ elementID: ElementID) {
+        self.elementID = elementID
+    }
+}
+
+// MARK: - WordEdit
+
+/// Semantic-layer Edit — addresses Word UI verbs and translates to
+/// `OOXMLEdit` via `lower()`.
+///
+/// Case names follow Word UI conventions (foundation ADR-005: verb prefix
+/// `apply*` disambiguates Edit-mutation from property-accessor style).
+public enum WordEdit: Edit, Equatable, Sendable {
+    /// Apply bold formatting to the selected range — equivalent to Word UI
+    /// Cmd-B on a selection.
+    ///
+    /// Within-single-paragraph: lower() returns a 1-element list with one
+    /// `OOXMLEdit.setBold`.
+    /// Range crosses paragraph boundary: lower() returns N-element list (one
+    /// `OOXMLEdit.setBold` per affected paragraph), per foundation ADR-002
+    /// Worked Example 4.
+    case applyBold(range: WordRange)
+
+    /// Apply a hyperlink to the selected range — equivalent to Word UI
+    /// Insert → Hyperlink (or Cmd-K).
+    ///
+    /// Lowers to `OOXMLEdit.insertHyperlink`. Atomicity (document.xml +
+    /// rels-part) is handled at OOXMLEdit level.
+    case applyLink(range: WordRange, url: URL)
+
+    /// Insert a new paragraph after the specified paragraph — equivalent to
+    /// Word UI positioning the cursor at end of paragraph + Enter + typing.
+    ///
+    /// Lowers to `OOXMLEdit.insertParagraph`.
+    case applyInsertParagraph(after: ParagraphRef, content: String)
+
+    // MARK: - Edit protocol conformance
+
+    /// Apply this WordEdit by calling `lower()` then applying each
+    /// `OOXMLEdit` in sequence via `WordDocument.apply(_:)`. Stub in §1
+    /// scaffold — full wiring lands in §2 (Document.apply public API).
+    public func apply(to document: WordDocument) throws -> WordDocument {
+        throw EditError.notImplemented("WordEdit.apply requires Document.apply(_:) wiring (§2 of #105 tasks)")
+    }
+
+    /// Lower this WordEdit to its `[OOXMLEdit]` translation. Stub in §1
+    /// scaffold — full implementations land in §7 of #105 tasks.
+    public func lower() -> [OOXMLEdit] {
+        // §7 will implement per-case logic. Returning empty is intentional
+        // scaffold marker — naturality tests in §9 will fail on stubs, which
+        // is the correct signal that implementation is pending.
+        []
+    }
+}

--- a/Sources/OOXMLSwift/Models/Document.swift
+++ b/Sources/OOXMLSwift/Models/Document.swift
@@ -15,6 +15,23 @@ public struct WordDocument: Equatable {
     public var revisions: RevisionsCollection = RevisionsCollection() // 修訂集合
     public var footnotes: FootnotesCollection = FootnotesCollection() // 腳註集合
     public var endnotes: EndnotesCollection = EndnotesCollection()    // 尾註集合
+
+    /// Append-only edit log (Phase 2 of PsychQuant/macdoc#99 architectural foundation).
+    ///
+    /// Set by `WordDocument.apply(_ edit:)` — each Edit's emitted Operations
+    /// are appended here before being materialized into `xmlTrees` via
+    /// `OperationReducer.materialize`. Sidecar persistence happens via
+    /// `OperationLog+JSONL` (out of WordDocument's scope).
+    ///
+    /// **Excluded from Equatable** by the custom `==` impl below — two
+    /// WordDocuments are "content-equal" iff their typed fields are equal;
+    /// edit-history equality is a separate concept (compare logs explicitly
+    /// via `doc1.operationLog == doc2.operationLog` when needed).
+    ///
+    /// Initial value is empty `OperationLog()` — DocxReader doesn't seed
+    /// log entries (the log starts when callers begin invoking `apply`).
+    public var operationLog: OperationLog = OperationLog()
+
     internal var nextBookmarkId: Int = 1       // 書籤 ID 計數器
     private var nextHyperlinkId: Int = 1      // 超連結 ID 計數器
 

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
@@ -80,10 +80,13 @@ final class DocumentApplyTests: XCTestCase {
         }
     }
 
-    func testApplyPropagatesNotImplementedFromWordEditLowerStub() {
-        // §1 WordEdit.lower() returns [] — empty list → no ops → no error.
-        // This documents the current stub behavior (will change in §7 when
-        // WordEdit.lower() returns real translations).
+    func testApplyThrowsOnStubWordEditEmptyLower() {
+        // §1 WordEdit.lower() returns [] — defensive check in WordDocument.apply
+        // detects non-OOXMLEdit returning empty list and throws notImplemented.
+        // This prevents the silent no-op trap that would let callers think
+        // their applyBold succeeded when actually nothing happened.
+        // §7 of macdoc#105 ships per-case WordEdit.lower() implementations;
+        // this guard becomes dormant for real cases.
         let doc = WordDocument()
         let range = WordRange(
             startRun: ElementID(libraryUUID: UUID()),
@@ -93,11 +96,55 @@ final class DocumentApplyTests: XCTestCase {
         )
         let edit = WordEdit.applyBold(range: range)
 
-        // Currently stub: WordEdit.lower() returns [] → no operations() called.
-        // §7 will make this throw notImplemented for the actual OOXMLEdit.
-        let result = try? doc.apply(edit)
-        XCTAssertNotNil(result, "Stub WordEdit.lower() empty list → no-op apply (will change in §7)")
-        XCTAssertEqual(doc, result, "Stub WordEdit apply is identity")
+        XCTAssertThrowsError(try doc.apply(edit)) { error in
+            guard case EditError.notImplemented(let message) = error else {
+                XCTFail("Expected .notImplemented on stub WordEdit, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("WordEdit") || message.contains("stub"),
+                          "Error references WordEdit/stub: \(message)")
+            XCTAssertTrue(message.contains("§7") || message.contains("macdoc#105"),
+                          "Error references task batch: \(message)")
+        }
+    }
+
+    func testApplyWrapsElementNotFoundAsOperationLogFailure() throws {
+        // Per spec.md "WordDocument.apply Public Method" item #4 (PHASED):
+        // target-not-found surfaces via Reducer-wrapping as
+        // EditError.operationLogFailure (until Phase 2c follow-up ships
+        // upfront EditError.pathNotFound validation).
+        //
+        // Build a WordDocument with a known paragraph, then issue an
+        // insertParagraph against a NON-EXISTENT ElementID. The Reducer
+        // throws elementNotFound, which WordDocument.apply wraps.
+        let paraUUID = UUID()
+        let textNode = XmlNode.text("present")
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+        let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+        wp.libraryUUID = paraUUID
+        let body = XmlNode.element(prefix: "w", localName: "body", children: [wp])
+        let root = XmlNode.element(prefix: "w", localName: "document", children: [body])
+        var doc = WordDocument()
+        doc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: root)
+
+        // Edit references an ElementID NOT in the doc
+        let bogusID = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.insertParagraph(after: bogusID, content: "new", styleId: nil)
+
+        XCTAssertThrowsError(try doc.apply(edit)) { error in
+            // Pin the CASE — spec.md PHASED behavior #4 says target-not-found
+            // surfaces as operationLogFailure (NOT as pathNotFound until Phase
+            // 2c upfront-validation lands). The wrapped `underlying` string
+            // format is intentionally not pinned (Swift's default
+            // localizedDescription is locale-dependent and the structured
+            // ElementID is lost in the wrap — a documented limitation of the
+            // PHASED contract; Phase 2c follow-up restores structured info).
+            guard case EditError.operationLogFailure = error else {
+                XCTFail("Expected .operationLogFailure (PHASED behavior per spec.md #4), got \(error)")
+                return
+            }
+        }
     }
 
     // MARK: - Sequence-folding apply

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
@@ -1,0 +1,157 @@
+// DocumentApplyTests.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// §2 of #105 tasks — Document.apply public API smoke tests.
+//
+// §2 ships the apply pipeline wiring (lower → operations → log append →
+// materialize → return new WordDocument). Tests here validate the pipeline
+// surfaces errors correctly through each layer:
+//   - notImplemented from OOXMLEdit.operations() (§1 stub) propagates
+//   - Empty edit list → no-op (identity)
+//   - operationLog field starts empty + is excluded from Equatable
+//   - Sequence-folding apply<S> chains correctly
+//
+// End-to-end behavior (apply actually modifies xmlTrees) lands in §3+ when
+// per-OOXMLEdit-case operations() implementations exist.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class DocumentApplyTests: XCTestCase {
+
+    // MARK: - operationLog field tests
+
+    func testOperationLogStartsEmpty() {
+        let doc = WordDocument()
+        XCTAssertEqual(doc.operationLog.entries.count, 0,
+                       "Fresh WordDocument has empty operationLog")
+    }
+
+    func testOperationLogExcludedFromEquatable() {
+        // Two WordDocuments with identical content but different logs should
+        // still be Equatable-equal (per design.md Decision 3).
+        var doc1 = WordDocument()
+        var doc2 = WordDocument()
+
+        let elementID = ElementID(libraryUUID: UUID())
+        doc1.operationLog.append(
+            .setText(target: elementID, text: "hello"),
+            source: .swift
+        )
+
+        XCTAssertNotEqual(doc1.operationLog, doc2.operationLog,
+                          "Logs differ — explicit log comparison shows it")
+        XCTAssertEqual(doc1, doc2,
+                       "Content equal — Equatable excludes log per Decision 3")
+    }
+
+    // MARK: - apply pipeline wiring tests
+
+    func testApplyReturnsNewDocument() throws {
+        // Use empty edit sequence — should be identity (no ops emitted)
+        let doc = WordDocument()
+        let result = try doc.apply([] as [any Edit])
+
+        XCTAssertEqual(doc, result, "Empty apply is identity (content equal)")
+        XCTAssertEqual(doc.operationLog.entries.count,
+                       result.operationLog.entries.count,
+                       "Empty apply doesn't append to log")
+    }
+
+    func testApplyPropagatesNotImplementedFromOperationsStub() {
+        // §1 scaffold has OOXMLEdit.operations() throwing notImplemented.
+        // §2 apply pipeline should surface that error through lower → operations.
+        let doc = WordDocument()
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+
+        XCTAssertThrowsError(try doc.apply(edit)) { error in
+            guard case EditError.notImplemented(let message) = error else {
+                XCTFail("Expected .notImplemented (from §1 stub), got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("§3-§6"),
+                          "Stub error message references task batch: \(message)")
+        }
+    }
+
+    func testApplyPropagatesNotImplementedFromWordEditLowerStub() {
+        // §1 WordEdit.lower() returns [] — empty list → no ops → no error.
+        // This documents the current stub behavior (will change in §7 when
+        // WordEdit.lower() returns real translations).
+        let doc = WordDocument()
+        let range = WordRange(
+            startRun: ElementID(libraryUUID: UUID()),
+            startOffset: 0,
+            endRun: ElementID(libraryUUID: UUID()),
+            endOffset: 5
+        )
+        let edit = WordEdit.applyBold(range: range)
+
+        // Currently stub: WordEdit.lower() returns [] → no operations() called.
+        // §7 will make this throw notImplemented for the actual OOXMLEdit.
+        let result = try? doc.apply(edit)
+        XCTAssertNotNil(result, "Stub WordEdit.lower() empty list → no-op apply (will change in §7)")
+        XCTAssertEqual(doc, result, "Stub WordEdit apply is identity")
+    }
+
+    // MARK: - Sequence-folding apply
+
+    func testApplyEmptySequence() throws {
+        let doc = WordDocument()
+        let result = try doc.apply([] as [any Edit])
+        XCTAssertEqual(doc, result, "Empty sequence apply is identity")
+    }
+
+    func testApplySingleEditViaSequence() {
+        // Single-element sequence should match single-edit apply behavior.
+        // Both throw the same notImplemented stub error (asserted separately
+        // to avoid nested XCTAssertThrowsError — Swift's throwing-closure
+        // type contract doesn't allow a throwing `try` inside the non-throwing
+        // ErrorHandler closure of the outer XCTAssertThrowsError).
+        let doc = WordDocument()
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+
+        // Sequence apply path
+        XCTAssertThrowsError(try doc.apply([edit] as [any Edit])) { seqError in
+            guard case EditError.notImplemented = seqError else {
+                XCTFail("Expected .notImplemented from sequence apply, got \(seqError)")
+                return
+            }
+        }
+
+        // Single apply path (separately)
+        XCTAssertThrowsError(try doc.apply(edit)) { singleError in
+            guard case EditError.notImplemented = singleError else {
+                XCTFail("Expected .notImplemented from single apply, got \(singleError)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Immutability tests
+
+    func testApplyDoesNotMutateInput() throws {
+        // Even on error, input doc should be unchanged
+        let doc = WordDocument()
+        let initialLogCount = doc.operationLog.entries.count
+
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        _ = try? doc.apply(edit)  // expected to throw notImplemented
+
+        XCTAssertEqual(doc.operationLog.entries.count, initialLogCount,
+                       "Input doc's log is unchanged after failed apply")
+    }
+
+    func testApplyMutationIsolation() throws {
+        // If apply DID succeed and modify newDoc, original doc's xmlTrees
+        // should NOT be affected (value semantics)
+        let doc = WordDocument()
+        let snapshotTrees = doc.xmlTrees
+
+        // Try a stub apply (will throw, but isolation should hold)
+        _ = try? doc.apply([] as [any Edit])
+
+        XCTAssertEqual(doc.xmlTrees.keys.sorted(), snapshotTrees.keys.sorted(),
+                       "Input doc's xmlTrees keys unchanged")
+    }
+}

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
@@ -31,7 +31,7 @@ final class DocumentApplyTests: XCTestCase {
         // Two WordDocuments with identical content but different logs should
         // still be Equatable-equal (per design.md Decision 3).
         var doc1 = WordDocument()
-        var doc2 = WordDocument()
+        let doc2 = WordDocument()
 
         let elementID = ElementID(libraryUUID: UUID())
         doc1.operationLog.append(
@@ -69,8 +69,8 @@ final class DocumentApplyTests: XCTestCase {
                 XCTFail("Expected .notImplemented (from §1 stub), got \(error)")
                 return
             }
-            XCTAssertTrue(message.contains("§3-§6"),
-                          "Stub error message references task batch: \(message)")
+            XCTAssertTrue(message.contains("§4-§6"),
+                          "Stub error message references remaining task batch: \(message)")
         }
     }
 

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
@@ -59,17 +59,23 @@ final class DocumentApplyTests: XCTestCase {
     }
 
     func testApplyPropagatesNotImplementedFromOperationsStub() {
-        // §1 scaffold has OOXMLEdit.operations() throwing notImplemented.
-        // §2 apply pipeline should surface that error through lower → operations.
+        // §2 apply pipeline should surface notImplemented errors from
+        // OOXMLEdit.operations() through lower → operations. Uses the LAST
+        // remaining stubbed case so this test survives each impl batch.
+        // DELETE once §5 insertHyperlink ships (no stubs left).
         let doc = WordDocument()
-        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        let edit = OOXMLEdit.insertHyperlink(
+            target: ElementID(libraryUUID: UUID()),
+            href: URL(string: "https://example.com")!,
+            displayText: nil
+        )
 
         XCTAssertThrowsError(try doc.apply(edit)) { error in
             guard case EditError.notImplemented(let message) = error else {
-                XCTFail("Expected .notImplemented (from §1 stub), got \(error)")
+                XCTFail("Expected .notImplemented (from §5 stub), got \(error)")
                 return
             }
-            XCTAssertTrue(message.contains("§5-§6"),
+            XCTAssertTrue(message.contains("§5"),
                           "Stub error message references remaining task batch: \(message)")
         }
     }
@@ -104,12 +110,14 @@ final class DocumentApplyTests: XCTestCase {
 
     func testApplySingleEditViaSequence() {
         // Single-element sequence should match single-edit apply behavior.
-        // Both throw the same notImplemented stub error (asserted separately
-        // to avoid nested XCTAssertThrowsError — Swift's throwing-closure
-        // type contract doesn't allow a throwing `try` inside the non-throwing
-        // ErrorHandler closure of the outer XCTAssertThrowsError).
+        // Uses last-remaining-stub case for cascade survival. DELETE once §5
+        // ships (no stubs left).
         let doc = WordDocument()
-        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        let edit = OOXMLEdit.insertHyperlink(
+            target: ElementID(libraryUUID: UUID()),
+            href: URL(string: "https://example.com")!,
+            displayText: nil
+        )
 
         // Sequence apply path
         XCTAssertThrowsError(try doc.apply([edit] as [any Edit])) { seqError in

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/DocumentApplyTests.swift
@@ -69,7 +69,7 @@ final class DocumentApplyTests: XCTestCase {
                 XCTFail("Expected .notImplemented (from §1 stub), got \(error)")
                 return
             }
-            XCTAssertTrue(message.contains("§4-§6"),
+            XCTAssertTrue(message.contains("§5-§6"),
                           "Stub error message references remaining task batch: \(message)")
         }
     }

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/EditProtocolTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/EditProtocolTests.swift
@@ -1,0 +1,151 @@
+// EditProtocolTests.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// §1.2 + §1.3 of #105 tasks — protocol conformance smoke tests.
+// Confirms scaffold is wired correctly: OOXMLEdit + WordEdit conform to
+// Edit; EditError is throwable; per-case construction works.
+//
+// End-to-end behavior tests live in DocumentApplyTests (§2.x) and
+// FullyFaithfulFunctorTests (§8.x).
+
+import XCTest
+@testable import OOXMLSwift
+
+final class EditProtocolTests: XCTestCase {
+
+    // MARK: - §1.2: OOXMLEdit conformance + construction
+
+    func testOOXMLEditEnumExists() {
+        let paraID = ElementID(libraryUUID: UUID())
+        let runID = ElementID(libraryUUID: UUID())
+
+        // All 5 canonical cases per design.md Decision 1 mapping table
+        let cases: [OOXMLEdit] = [
+            .insertParagraph(after: paraID, content: "hello", styleId: nil),
+            .insertParagraphBefore(before: paraID, content: "world", styleId: "Heading1"),
+            .setBold(target: runID, value: true),
+            .insertHyperlink(target: runID, href: URL(string: "https://example.com")!, displayText: nil),
+            .removeParagraph(target: paraID),
+        ]
+
+        XCTAssertEqual(cases.count, 5, "All 5 canonical OOXMLEdit cases should construct")
+
+        // Edit conformance: each case can be type-erased to `any Edit`
+        let edits: [any Edit] = cases
+        XCTAssertEqual(edits.count, 5)
+    }
+
+    func testOOXMLEditLowerReturnsIdentity() {
+        let runID = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.setBold(target: runID, value: true)
+
+        let lowered = edit.lower()
+        XCTAssertEqual(lowered.count, 1, "OOXMLEdit.lower() is identity — returns [self]")
+        XCTAssertEqual(lowered[0], edit, "Lowered element equals self")
+    }
+
+    func testOOXMLEditApplyThrowsNotImplementedInScaffold() {
+        // Phase 2 §1 scaffold throws notImplemented for apply.
+        // §2 (Document.apply wiring) makes this pass.
+        let document = WordDocument()
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+
+        XCTAssertThrowsError(try edit.apply(to: document)) { error in
+            guard case EditError.notImplemented(let message) = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("§2"), "Error message references §2 task: \(message)")
+        }
+    }
+
+    // MARK: - §1.3: WordEdit conformance + construction
+
+    func testWordEditEnumExists() {
+        let r1 = ElementID(libraryUUID: UUID())
+        let r2 = ElementID(libraryUUID: UUID())
+        let p1 = ElementID(libraryUUID: UUID())
+
+        let range = WordRange(startRun: r1, startOffset: 0, endRun: r2, endOffset: 5)
+        let paraRef = ParagraphRef(p1)
+
+        // All 3 canonical cases per design.md Decision 2 mapping table
+        let cases: [WordEdit] = [
+            .applyBold(range: range),
+            .applyLink(range: range, url: URL(string: "https://example.com")!),
+            .applyInsertParagraph(after: paraRef, content: "hello"),
+        ]
+
+        XCTAssertEqual(cases.count, 3, "All 3 canonical WordEdit cases should construct")
+
+        let edits: [any Edit] = cases
+        XCTAssertEqual(edits.count, 3)
+    }
+
+    func testWordEditLowerReturnsEmptyInScaffold() {
+        // Phase 2 §1 scaffold returns []. §7 lands per-case lower() bodies.
+        // Naturality tests in §9 will catch when stub returns persist past §7.
+        let range = WordRange(
+            startRun: ElementID(libraryUUID: UUID()),
+            startOffset: 0,
+            endRun: ElementID(libraryUUID: UUID()),
+            endOffset: 5
+        )
+        let edit = WordEdit.applyBold(range: range)
+        XCTAssertTrue(edit.lower().isEmpty, "Scaffold WordEdit.lower() returns [] (TODO marker)")
+    }
+
+    func testWordRangeIsEquatable() {
+        let r1 = ElementID(libraryUUID: UUID())
+        let r2 = ElementID(libraryUUID: UUID())
+
+        let range1 = WordRange(startRun: r1, startOffset: 0, endRun: r2, endOffset: 5)
+        let range2 = WordRange(startRun: r1, startOffset: 0, endRun: r2, endOffset: 5)
+        let range3 = WordRange(startRun: r1, startOffset: 0, endRun: r2, endOffset: 6)
+
+        XCTAssertEqual(range1, range2)
+        XCTAssertNotEqual(range1, range3)
+    }
+
+    // MARK: - EditError tests
+
+    func testEditErrorCasesAreThrowable() {
+        let runID = ElementID(libraryUUID: UUID())
+
+        let errors: [EditError] = [
+            .pathNotFound(runID),
+            .preserveViolation(part: "word/document.xml", expected: "abc", actual: "xyz"),
+            .unsupportedOperation("setBold requires Run target"),
+            .notImplemented("§1 scaffold"),
+            .operationLogFailure(underlying: "reducer failed"),
+        ]
+        XCTAssertEqual(errors.count, 5)
+
+        for error in errors {
+            XCTAssertThrowsError(try { throw error }())
+        }
+    }
+
+    func testEditErrorEquatable() {
+        let runID = ElementID(libraryUUID: UUID())
+        let a: EditError = .pathNotFound(runID)
+        let b: EditError = .pathNotFound(runID)
+        XCTAssertEqual(a, b)
+
+        let c: EditError = .pathNotFound(ElementID(libraryUUID: UUID()))
+        XCTAssertNotEqual(a, c)
+    }
+
+    // MARK: - OOXMLEdit+Operation extension
+
+    func testOperationsExtensionThrowsNotImplemented() {
+        // §1.4 placeholder — per-case operations() impl lands in §3-§6.
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/EditProtocolTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/EditProtocolTests.swift
@@ -139,8 +139,15 @@ final class EditProtocolTests: XCTestCase {
     // MARK: - OOXMLEdit+Operation extension
 
     func testOperationsExtensionThrowsNotImplemented() {
-        // §1.4 placeholder — per-case operations() impl lands in §3-§6.
-        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        // §1.4 stub-mechanism test — uses the LAST remaining stubbed case so
+        // it survives each impl batch (§3, §4, §6 already shipped; §5
+        // insertHyperlink is the only remaining stub). DELETE this test
+        // once §5 ships (no stubs left).
+        let edit = OOXMLEdit.insertHyperlink(
+            target: ElementID(libraryUUID: UUID()),
+            href: URL(string: "https://example.com")!,
+            displayText: nil
+        )
         XCTAssertThrowsError(try edit.operations()) { error in
             guard case EditError.notImplemented = error else {
                 XCTFail("Expected .notImplemented, got \(error)")

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphE2ETests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphE2ETests.swift
@@ -1,0 +1,185 @@
+// InsertParagraphE2ETests.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// §3.3 of #105 tasks — END-TO-END test for OOXMLEdit.insertParagraph.
+//
+// Now unblocked by ooxml-swift#71 (Phase 2c reducer): the full chain
+//   Edit → lower() → operations() → log append → materialize → new WordDocument
+// can mutate xmlTrees and we can inspect the result.
+//
+// Scope: synthesized single-part WordDocument (xmlTrees["word/document.xml"]
+// only — no styles.xml, comments.xml, etc.). Real-.docx fixture tests come
+// after the multi-part scoping fix is in place — see follow-up note in
+// WordDocument+Apply.swift.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class InsertParagraphE2ETests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a WordDocument whose `xmlTrees["word/document.xml"]` contains
+    /// the given paragraphs. Returns the doc + each paragraph's ElementID.
+    private func makeSinglePartDoc(paragraphs texts: [String]) -> (WordDocument, [ElementID]) {
+        var paraIDs: [ElementID] = []
+        var paragraphs: [XmlNode] = []
+
+        for text in texts {
+            let paraUUID = UUID()
+            paraIDs.append(ElementID(libraryUUID: paraUUID))
+
+            let textNode = XmlNode.text(text)
+            let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+            let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+            let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+            wp.libraryUUID = paraUUID
+            paragraphs.append(wp)
+        }
+
+        let body = XmlNode.element(prefix: "w", localName: "body", children: paragraphs)
+        let doc = XmlNode.element(prefix: "w", localName: "document", children: [body])
+
+        var wordDoc = WordDocument()
+        wordDoc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: doc)
+        return (wordDoc, paraIDs)
+    }
+
+    /// Extracts text of all <w:t> in the document.xml part, in order.
+    private func extractTextFromDocPart(_ doc: WordDocument) -> [String] {
+        guard let tree = doc.xmlTrees["word/document.xml"] else { return [] }
+        var result: [String] = []
+        func walk(_ node: XmlNode) {
+            if node.kind == .element && node.localName == "t" {
+                for child in node.children where child.kind == .text {
+                    result.append(child.textContent)
+                }
+            }
+            for child in node.children {
+                walk(child)
+            }
+        }
+        walk(tree.root)
+        return result
+    }
+
+    // MARK: - End-to-end: OOXMLEdit.insertParagraph mutates xmlTrees
+
+    func testInsertParagraphAfterMutatesDocumentPart() throws {
+        let (doc, paraIDs) = makeSinglePartDoc(paragraphs: ["first"])
+        XCTAssertEqual(extractTextFromDocPart(doc), ["first"], "baseline")
+
+        let edit = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "second", styleId: nil)
+        let result = try doc.apply(edit)
+
+        XCTAssertEqual(extractTextFromDocPart(result), ["first", "second"],
+                       "After apply, document.xml has new paragraph after target")
+    }
+
+    func testInsertParagraphBeforeMutatesDocumentPart() throws {
+        let (doc, paraIDs) = makeSinglePartDoc(paragraphs: ["second"])
+
+        let edit = OOXMLEdit.insertParagraphBefore(before: paraIDs[0], content: "first", styleId: nil)
+        let result = try doc.apply(edit)
+
+        XCTAssertEqual(extractTextFromDocPart(result), ["first", "second"],
+                       "After apply, new paragraph appears BEFORE target")
+    }
+
+    func testRemoveParagraphMutatesDocumentPart() throws {
+        let (doc, paraIDs) = makeSinglePartDoc(paragraphs: ["a", "b", "c"])
+
+        let edit = OOXMLEdit.removeParagraph(target: paraIDs[1])
+        let result = try doc.apply(edit)
+
+        XCTAssertEqual(extractTextFromDocPart(result), ["a", "c"],
+                       "After apply, target paragraph removed; siblings preserved")
+    }
+
+    // MARK: - End-to-end: WordDocument immutability + operationLog accumulation
+
+    func testApplyDoesNotMutateSelfOnSuccess() throws {
+        let (doc, paraIDs) = makeSinglePartDoc(paragraphs: ["first"])
+
+        let edit = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "second", styleId: nil)
+        _ = try doc.apply(edit)
+
+        XCTAssertEqual(extractTextFromDocPart(doc), ["first"],
+                       "Original doc unchanged after apply (value semantics)")
+    }
+
+    func testApplyAppendsToOperationLog() throws {
+        let (doc, paraIDs) = makeSinglePartDoc(paragraphs: ["first"])
+        let logCountBefore = doc.operationLog.entries.count
+
+        let edit = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "second", styleId: nil)
+        let result = try doc.apply(edit)
+
+        XCTAssertEqual(result.operationLog.entries.count, logCountBefore + 1,
+                       "After single-op apply, log has exactly one more entry")
+        XCTAssertEqual(doc.operationLog.entries.count, logCountBefore,
+                       "Original doc's log unchanged (immutable apply)")
+
+        // The new entry's op should be the expected insertParagraphAfter.
+        let lastEntry = result.operationLog.entries.last!
+        guard case .insertParagraphAfter(let after, let payload) = lastEntry.op else {
+            XCTFail("Expected insertParagraphAfter in log, got \(lastEntry.op)")
+            return
+        }
+        XCTAssertEqual(after, paraIDs[0])
+        XCTAssertEqual(payload.text, "second")
+    }
+
+    // MARK: - End-to-end: setBold via WordDocument.apply
+
+    func testSetBoldMutatesRunRPr() throws {
+        // Synthesize doc with a paragraph containing one Run with libraryUUID.
+        let runUUID = UUID()
+        let textNode = XmlNode.text("hello")
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+        wr.libraryUUID = runUUID
+        let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+        let body = XmlNode.element(prefix: "w", localName: "body", children: [wp])
+        let root = XmlNode.element(prefix: "w", localName: "document", children: [body])
+
+        var doc = WordDocument()
+        doc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: root)
+
+        let runID = ElementID(libraryUUID: runUUID)
+        let edit = OOXMLEdit.setBold(target: runID, value: true)
+        let result = try doc.apply(edit)
+
+        // Inspect result: target run should have <w:rPr><w:b/></w:rPr>
+        guard let tree = result.xmlTrees["word/document.xml"],
+              let run = OperationReducer.findNode(elementID: runID, in: tree),
+              let rPr = run.children.first(where: { $0.kind == .element && $0.localName == "rPr" }) else {
+            XCTFail("Expected run with rPr in result")
+            return
+        }
+        let hasBold = rPr.children.contains { $0.kind == .element && $0.localName == "b" }
+        XCTAssertTrue(hasBold, "After setBold(value: true), run has <w:b/> in rPr")
+    }
+
+    // MARK: - End-to-end: edit chain through apply<Sequence>
+
+    func testApplySequenceChainsEditsViaDeterministicIDs() throws {
+        let (doc, paraIDs) = makeSinglePartDoc(paragraphs: ["a"])
+
+        // First insert "b" after "a"; new paragraph's libraryUUID == opID-of-first-edit.
+        // But OOXMLEdit doesn't expose opID — apply() generates fresh UUID for each op.
+        // So we can't chain via deterministic IDs from OOXMLEdit alone.
+        //
+        // What we CAN test: applying two independent edits in sequence yields
+        // the expected text order, even if the second edit can't reference
+        // the first's new paragraph by ID.
+        let editB = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "b", styleId: nil)
+        let editC = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "c", styleId: nil)
+        // Both inserts target the SAME "a" — second insert goes AFTER "a",
+        // before the previously-inserted "b". Result: [a, c, b].
+        let result = try doc.apply([editB, editC] as [any Edit])
+
+        XCTAssertEqual(extractTextFromDocPart(result), ["a", "c", "b"],
+                       "Two inserts after same target: second goes between (LIFO order)")
+    }
+}

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphTests.swift
@@ -1,0 +1,132 @@
+// InsertParagraphTests.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// §3 of #105 tasks — insertParagraph + insertParagraphBefore emission tests.
+//
+// SCOPE: Validates OOXMLEdit → Operation translation (the `.operations()`
+// method). Pure-data assertions; does NOT invoke OperationReducer.
+//
+// END-TO-END (apply actually mutates xmlTrees) is DEFERRED — see design.md
+// Decision 6 (OpLog Phase 2c dependency). The Reducer currently throws
+// `malformedOp("Phase 2c implements this op")` for `insertParagraphAfter`
+// and `insertParagraphBefore`. Once OpLog Phase 2c lands, add e2e tests
+// that build a synthesized WordDocument, apply the Edit, and assert
+// xmlTrees["word/document.xml"] contains the new paragraph at the
+// expected position.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class InsertParagraphTests: XCTestCase {
+
+    // MARK: - insertParagraph (after) emission
+
+    func testInsertParagraphEmitsInsertParagraphAfter() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.insertParagraph(
+            after: target,
+            content: "Hello world",
+            styleId: nil
+        )
+
+        let ops = try edit.operations()
+        XCTAssertEqual(ops.count, 1, "insertParagraph lowers to exactly one Operation")
+
+        guard case .insertParagraphAfter(let after, let payload) = ops[0] else {
+            XCTFail("Expected Operation.insertParagraphAfter, got \(ops[0])")
+            return
+        }
+        XCTAssertEqual(after, target, "after: ElementID round-trips")
+        XCTAssertEqual(payload.text, "Hello world", "content lowers to ParagraphPayload.text")
+        XCTAssertNil(payload.styleId, "nil styleId stays nil")
+    }
+
+    func testInsertParagraphPreservesStyleId() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.insertParagraph(
+            after: target,
+            content: "Section heading",
+            styleId: "Heading1"
+        )
+
+        let ops = try edit.operations()
+        guard case .insertParagraphAfter(_, let payload) = ops[0] else {
+            XCTFail("Expected Operation.insertParagraphAfter")
+            return
+        }
+        XCTAssertEqual(payload.styleId, "Heading1", "styleId lowers verbatim")
+    }
+
+    func testInsertParagraphEmptyContent() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.insertParagraph(after: target, content: "", styleId: nil)
+
+        let ops = try edit.operations()
+        guard case .insertParagraphAfter(_, let payload) = ops[0] else {
+            XCTFail("Expected Operation.insertParagraphAfter")
+            return
+        }
+        XCTAssertEqual(payload.text, "", "Empty content lowers to empty ParagraphPayload.text")
+    }
+
+    // MARK: - insertParagraphBefore emission
+
+    func testInsertParagraphBeforeEmitsInsertParagraphBefore() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.insertParagraphBefore(
+            before: target,
+            content: "Prologue",
+            styleId: "Quote"
+        )
+
+        let ops = try edit.operations()
+        XCTAssertEqual(ops.count, 1, "insertParagraphBefore lowers to exactly one Operation")
+
+        guard case .insertParagraphBefore(let before, let payload) = ops[0] else {
+            XCTFail("Expected Operation.insertParagraphBefore, got \(ops[0])")
+            return
+        }
+        XCTAssertEqual(before, target, "before: ElementID round-trips")
+        XCTAssertEqual(payload.text, "Prologue")
+        XCTAssertEqual(payload.styleId, "Quote")
+    }
+
+    // MARK: - Stub still throws for unimplemented cases
+
+    func testSetBoldStillThrowsNotImplemented() {
+        let edit = OOXMLEdit.setBold(target: ElementID(libraryUUID: UUID()), value: true)
+
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented(let msg) = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("§4-§6"),
+                          "Error message references task batch: \(msg)")
+        }
+    }
+
+    func testRemoveParagraphStillThrowsNotImplemented() {
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testInsertHyperlinkStillThrowsNotImplemented() {
+        let edit = OOXMLEdit.insertHyperlink(
+            target: ElementID(libraryUUID: UUID()),
+            href: URL(string: "https://example.com")!,
+            displayText: "click"
+        )
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphTests.swift
@@ -92,19 +92,9 @@ final class InsertParagraphTests: XCTestCase {
     }
 
     // MARK: - Stub still throws for unimplemented cases
-
-    func testSetBoldStillThrowsNotImplemented() {
-        let edit = OOXMLEdit.setBold(target: ElementID(libraryUUID: UUID()), value: true)
-
-        XCTAssertThrowsError(try edit.operations()) { error in
-            guard case EditError.notImplemented(let msg) = error else {
-                XCTFail("Expected .notImplemented, got \(error)")
-                return
-            }
-            XCTAssertTrue(msg.contains("§4-§6"),
-                          "Error message references task batch: \(msg)")
-        }
-    }
+    //
+    // setBold landed in §4 — assertion moved to SetBoldTests.
+    // removeParagraph + insertHyperlink remain in §5-§6 (still stubs).
 
     func testRemoveParagraphStillThrowsNotImplemented() {
         let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertParagraphTests.swift
@@ -93,18 +93,9 @@ final class InsertParagraphTests: XCTestCase {
 
     // MARK: - Stub still throws for unimplemented cases
     //
-    // setBold landed in §4 — assertion moved to SetBoldTests.
-    // removeParagraph + insertHyperlink remain in §5-§6 (still stubs).
-
-    func testRemoveParagraphStillThrowsNotImplemented() {
-        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
-        XCTAssertThrowsError(try edit.operations()) { error in
-            guard case EditError.notImplemented = error else {
-                XCTFail("Expected .notImplemented, got \(error)")
-                return
-            }
-        }
-    }
+    // setBold landed in §4 — assertion in SetBoldTests.
+    // removeParagraph landed in §6 — assertion in RemoveParagraphTests.
+    // insertHyperlink is the only remaining stub (§5 pending).
 
     func testInsertHyperlinkStillThrowsNotImplemented() {
         let edit = OOXMLEdit.insertHyperlink(

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/RemoveParagraphTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/RemoveParagraphTests.swift
@@ -1,0 +1,59 @@
+// RemoveParagraphTests.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// §6 of #105 tasks — removeParagraph emission tests.
+//
+// SCOPE: Validates OOXMLEdit.removeParagraph → Operation.removeParagraph
+// translation. End-to-end deferred behind ooxml-swift#71.
+//
+// Note: Operation.removeParagraph uses `id:` label, OOXMLEdit.removeParagraph
+// uses `target:`. The lowering must translate label names — this test pins
+// the label translation to prevent silent breakage if either side renames.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class RemoveParagraphTests: XCTestCase {
+
+    func testRemoveParagraphEmitsOperationRemoveParagraph() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.removeParagraph(target: target)
+
+        let ops = try edit.operations()
+        XCTAssertEqual(ops.count, 1, "removeParagraph lowers to exactly one Operation")
+
+        guard case .removeParagraph(let opId) = ops[0] else {
+            XCTFail("Expected Operation.removeParagraph, got \(ops[0])")
+            return
+        }
+        XCTAssertEqual(opId, target,
+                       "OOXMLEdit.removeParagraph(target:) → Operation.removeParagraph(id:) — ElementID round-trips across label rename")
+    }
+
+    func testRemoveParagraphLowerReturnsSelf() {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.removeParagraph(target: target)
+
+        let lowered = edit.lower()
+        XCTAssertEqual(lowered.count, 1)
+        XCTAssertEqual(lowered[0], edit, "OOXMLEdit.lower() is identity")
+    }
+
+    // MARK: - Insertions remain stubbed (insertHyperlink only — §5 pending)
+
+    func testInsertHyperlinkStillThrowsAfterRemoveParagraphImplemented() {
+        let edit = OOXMLEdit.insertHyperlink(
+            target: ElementID(libraryUUID: UUID()),
+            href: URL(string: "https://example.com")!,
+            displayText: "click"
+        )
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented(let msg) = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("§5"),
+                          "Error references composite design pending: \(msg)")
+        }
+    }
+}

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/SetBoldTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/SetBoldTests.swift
@@ -79,18 +79,9 @@ final class SetBoldTests: XCTestCase {
     }
 
     // MARK: - Remaining stubs still throw
-
-    func testRemoveParagraphStillThrowsAfterSetBoldImplemented() {
-        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
-        XCTAssertThrowsError(try edit.operations()) { error in
-            guard case EditError.notImplemented(let msg) = error else {
-                XCTFail("Expected .notImplemented, got \(error)")
-                return
-            }
-            XCTAssertTrue(msg.contains("§5-§6"),
-                          "Stub error references remaining task batch: \(msg)")
-        }
-    }
+    //
+    // removeParagraph landed in §6 — coverage in RemoveParagraphTests.
+    // insertHyperlink is the only remaining stub (§5).
 
     func testInsertHyperlinkStillThrowsAfterSetBoldImplemented() {
         let edit = OOXMLEdit.insertHyperlink(

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/SetBoldTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/SetBoldTests.swift
@@ -1,0 +1,108 @@
+// SetBoldTests.swift
+// EditAlgebra — Phase 2 of ooxml-edit-isomorphism-foundation (PsychQuant/macdoc#99)
+//
+// §4 of #105 tasks — setBold emission tests.
+//
+// SCOPE: Validates OOXMLEdit.setBold → Operation.setRunFormat translation.
+// End-to-end deferred behind ooxml-swift#71 (OpLog Phase 2c).
+
+import XCTest
+@testable import OOXMLSwift
+
+final class SetBoldTests: XCTestCase {
+
+    // MARK: - Emission: setBold(value: true) → RunFormatPayload(bold: true)
+
+    func testSetBoldTrueEmitsSetRunFormatWithBoldTrue() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.setBold(target: target, value: true)
+
+        let ops = try edit.operations()
+        XCTAssertEqual(ops.count, 1, "setBold lowers to exactly one Operation")
+
+        guard case .setRunFormat(let opTarget, let payload) = ops[0] else {
+            XCTFail("Expected Operation.setRunFormat, got \(ops[0])")
+            return
+        }
+        XCTAssertEqual(opTarget, target, "target: ElementID round-trips")
+        XCTAssertEqual(payload.bold, true, "value: true lowers to RunFormatPayload.bold = true")
+    }
+
+    // MARK: - Emission: setBold(value: false) → RunFormatPayload(bold: false)
+    //
+    // Important contract: `false` is EXPLICIT — payload.bold == false, NOT nil.
+    // nil would mean "leave bold unchanged", but the user said "set to false"
+    // (remove bold). See design.md Decision 1 + RunFormatPayload field-semantics
+    // (nil = leave unchanged, Bool = set to that value).
+
+    func testSetBoldFalseEmitsSetRunFormatWithBoldFalse() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.setBold(target: target, value: false)
+
+        let ops = try edit.operations()
+        guard case .setRunFormat(_, let payload) = ops[0] else {
+            XCTFail("Expected Operation.setRunFormat")
+            return
+        }
+        XCTAssertEqual(payload.bold, false,
+                       "value: false → explicit RunFormatPayload.bold = false (NOT nil)")
+        XCTAssertNotNil(payload.bold,
+                        "bold MUST be non-nil; nil means 'leave unchanged'")
+    }
+
+    // MARK: - Emission: other format fields stay nil (single-purpose Edit)
+
+    func testSetBoldDoesNotTouchOtherFormatFields() throws {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.setBold(target: target, value: true)
+
+        let ops = try edit.operations()
+        guard case .setRunFormat(_, let payload) = ops[0] else {
+            XCTFail("Expected Operation.setRunFormat")
+            return
+        }
+        XCTAssertNil(payload.italic, "setBold leaves italic unchanged (nil)")
+        XCTAssertNil(payload.underline, "setBold leaves underline unchanged (nil)")
+        XCTAssertNil(payload.fontSizeHalfPoints, "setBold leaves fontSize unchanged (nil)")
+        XCTAssertNil(payload.color, "setBold leaves color unchanged (nil)")
+    }
+
+    // MARK: - lower() identity (OOXMLEdit is its own lowering)
+
+    func testSetBoldLowerReturnsSelf() {
+        let target = ElementID(libraryUUID: UUID())
+        let edit = OOXMLEdit.setBold(target: target, value: true)
+
+        let lowered = edit.lower()
+        XCTAssertEqual(lowered.count, 1, "OOXMLEdit.lower() is identity (returns [self])")
+        XCTAssertEqual(lowered[0], edit, "OOXMLEdit.lower() returns self verbatim")
+    }
+
+    // MARK: - Remaining stubs still throw
+
+    func testRemoveParagraphStillThrowsAfterSetBoldImplemented() {
+        let edit = OOXMLEdit.removeParagraph(target: ElementID(libraryUUID: UUID()))
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented(let msg) = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("§5-§6"),
+                          "Stub error references remaining task batch: \(msg)")
+        }
+    }
+
+    func testInsertHyperlinkStillThrowsAfterSetBoldImplemented() {
+        let edit = OOXMLEdit.insertHyperlink(
+            target: ElementID(libraryUUID: UUID()),
+            href: URL(string: "https://example.com")!,
+            displayText: "click"
+        )
+        XCTAssertThrowsError(try edit.operations()) { error in
+            guard case EditError.notImplemented = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ships the Phase 2 Swift runtime for the macdoc#99 ooxml-edit-isomorphism-foundation: `Edit` protocol + `OOXMLEdit` enum + `WordEdit` enum + `WordDocument.apply` public method + end-to-end apply tests.

Spec-side change shipped via [macdoc PR #109](https://github.com/PsychQuant/macdoc/pull/109) (merged) — see `openspec/changes/ooxml-edit-algebra-implementation/` for proposal/design/tasks/spec/.openspec.yaml.

Depends on (now in main): #72 (Phase 2c reducer critical-path).

## What ships

### `Sources/OOXMLSwift/EditAlgebra/` (new module subdirectory)

- **`Edit.swift`** — `public protocol Edit { func apply(to: WordDocument) throws -> WordDocument; func lower() -> [OOXMLEdit] }` + `public enum EditError: Error, Equatable, Sendable` with 5 cases (pathNotFound, preserveViolation, unsupportedOperation, notImplemented, operationLogFailure).
- **`OOXMLEdit.swift`** — `public enum OOXMLEdit: Edit, Equatable, Sendable` with 5 cases:
  - `insertParagraph(after: ElementID, content: String, styleId: String?)`
  - `insertParagraphBefore(before: ElementID, content: String, styleId: String?)`
  - `setBold(target: ElementID, value: Bool)`
  - `insertHyperlink(target: ElementID, href: URL, displayText: String?)` — stub (composite design pending)
  - `removeParagraph(target: ElementID)`
- **`WordEdit.swift`** — `public enum WordEdit: Edit, Equatable, Sendable` with 3 cases (applyBold, applyLink, applyInsertParagraph) + `WordRange` + `ParagraphRef` structs. Stub `lower()` returns `[]` (per-case implementations in macdoc#105 §7, follow-up).
- **`OOXMLEdit+Operation.swift`** — `OOXMLEdit.operations() throws -> [Operation]` per-case mapping (Decision 1 in macdoc#109 design.md): 4 of 5 cases implemented; `insertHyperlink` throws notImplemented pending composite design.
- **`WordDocument+Apply.swift`** — `public func apply(_ edit: any Edit) throws -> WordDocument` + sequence-folding variant. Routes through OperationLog + Reducer.materialize. Per-op part scoping fix is documented as a follow-up (currently iterates ALL parts; works on synthesized single-part docs).

### `Sources/OOXMLSwift/Models/Document.swift` (additive modification)

- New field: `public var operationLog: OperationLog = OperationLog()`
- Customized Equatable to EXCLUDE operationLog from content equality (existing test parity preserved — two WordDocuments with same content but different edit history compare equal).

### `Tests/OOXMLSwiftTests/EditAlgebraTests/` (new test target — 38 tests)

| File | Tests | Coverage |
|---|---|---|
| `EditProtocolTests.swift` | 9 | Protocol conformance smoke + WordRange equality + WordEdit shape |
| `DocumentApplyTests.swift` | 9 | Apply pipeline wiring, sequence-fold, immutability, log-append |
| `InsertParagraphTests.swift` | 6 | Emission: OOXMLEdit.insertParagraph + insertParagraphBefore → correct Operation |
| `SetBoldTests.swift` | 6 | Emission: OOXMLEdit.setBold → setRunFormat(bold:); pins `false` = explicit (not nil) |
| `RemoveParagraphTests.swift` | 3 | Emission: pins `target:` → `id:` label translation |
| `InsertParagraphE2ETests.swift` | 7 | **End-to-end**: doc.apply(edit) mutates xmlTrees through full chain |

All 38 EditAlgebra tests pass + full ooxml-swift suite 1034 pass / 1 skipped / 0 fail.

## Architectural milestone

The full chain `Edit → lower → operations → log → materialize → new WordDocument` now mutates `xmlTrees` end-to-end. The macdoc#99 ADRs are empirically validated, not just decision-pinned.

## Design decisions (full rationale in macdoc#109 design.md)

1. **WordDocument owns OperationLog** (rejected EditableDocument wrapper after user pushback re: type-surface bifurcation)
2. **Custom Equatable excludes operationLog** (content equality ≠ history equality)
3. **Immutable apply** (returns new WordDocument; input unchanged)
4. **Deterministic ID derivation from opID** in Reducer (event-sourcing invariant)
5. **OOXMLEdit.lower() is identity** (`[self]`) — OOXMLEdit IS the syntactic layer

## Known phased follow-ups (documented in macdoc#109 spec + tasks)

| Item | Status | Tracking |
|---|---|---|
| §5 insertHyperlink emission | Pending composite design checkpoint (5 open Qs) | macdoc#105 |
| §5 insertHyperlink e2e | Needs `insertNode` + `updateAttribute` reducer cases | ooxml-swift#71 follow-up |
| §2.2 EditError.pathNotFound early validation | Phased — depends on per-op part scoping | macdoc#105 |
| §2.3 EditError.preserveViolation defensive c14n | Phased — depends on c14n helper + per-op scoping | macdoc#105 |
| §7 WordEdit lower() implementations | TODO | macdoc#105 |
| §8 property tests / §9 naturality tests | TODO | macdoc#105 |
| Per-op part scoping in WordDocument+Apply.swift | Required before real-.docx fixture tests | macdoc#105 follow-up |
| Remaining 10 Phase 2c reducer cases | Tracked | ooxml-swift#71 |

## Test plan

- [x] `swift test --filter EditAlgebraTests` — 38 tests pass
- [x] Full ooxml-swift suite — 1034 pass, 0 fail
- [x] CodeQL CI (will check on PR open)
- [ ] Downstream: macdoc CLI still builds + tests pass against the new ooxml-swift main

## Linked work

- macdoc#99 — foundation (merged in macdoc PR #106)
- macdoc#105 — Phase 2 Spectra change ([macdoc PR #109 merged](https://github.com/PsychQuant/macdoc/pull/109))
- ooxml-swift#71 — OpLog Phase 2c remaining cases (open, follow-up scope)
- ooxml-swift#72 — Phase 2c reducer critical-path (merged, this PR depends on it)

Refs PsychQuant/macdoc#99
Refs PsychQuant/macdoc#105
