### PR TITLE
feat(EditAlgebra): §7 WordEdit.lower() per-case implementations (macdoc#110)

### DIFF
--- a/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
@@ -40,16 +40,16 @@ extension WordDocument {
         //    OOXMLEdit+Operation.swift (per design.md Decision 1).
         let ooxmlEdits = edit.lower()
 
-        // Defensive: detect stub Edits that silently lower to []. OOXMLEdit's
+        // Defensive: detect Edits that silently lower to []. OOXMLEdit's
         // lower() always returns [self] (identity), so empty here means a
-        // non-OOXMLEdit (typically a stub WordEdit case) returned []. Without
-        // this check, doc.apply(stubWordEdit) would return the input doc
-        // unchanged — a silent no-op that masks the unimplemented case. §7
-        // of macdoc#105 ships WordEdit.lower() per-case implementations; this
-        // guard becomes dormant once real cases return non-empty [OOXMLEdit].
+        // non-OOXMLEdit (typically WordEdit) returned []. This happens in two
+        // scenarios: (1) unimplemented stub case, (2) input combination that
+        // lower() can't resolve without document context (e.g., cross-
+        // paragraph WordRange in applyBold — see WordEdit.swift). Both
+        // surface as notImplemented since the apply call can't proceed.
         if ooxmlEdits.isEmpty && !(edit is OOXMLEdit) {
             throw EditError.notImplemented(
-                "Edit of type \(type(of: edit)) returned empty lower() — likely a stub case. Per-case WordEdit.lower() implementations land in §7 of PsychQuant/macdoc#105."
+                "Edit of type \(type(of: edit)) returned empty lower(). Either the case is not yet implemented (see macdoc#110 / macdoc#105 §7), or the input combination requires document context that the non-throwing no-arg lower() protocol can't access (e.g., cross-paragraph WordRange)."
             )
         }
 

--- a/Sources/OOXMLSwift/EditAlgebra/WordEdit.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordEdit.swift
@@ -106,12 +106,67 @@ public enum WordEdit: Edit, Equatable, Sendable {
         throw EditError.notImplemented("WordEdit.apply requires Document.apply(_:) wiring (§2 of #105 tasks)")
     }
 
-    /// Lower this WordEdit to its `[OOXMLEdit]` translation. Stub in §1
-    /// scaffold — full implementations land in §7 of #105 tasks.
+    /// Lower this WordEdit to its `[OOXMLEdit]` translation.
+    ///
+    /// Per macdoc#105 design.md Decision 2 + spec.md "WordEdit Enum with 3
+    /// Canonical Cases". `lower()` is non-throwing and takes no document
+    /// context (per the `Edit` protocol). Cases that require doc context to
+    /// resolve (e.g., cross-paragraph WordRange in applyBold needs to
+    /// enumerate intermediate Runs) return `[]`, which triggers the silent-
+    /// noop guard in `WordDocument.apply` → throws `notImplemented` with a
+    /// message identifying the unsupported input combination.
     public func lower() -> [OOXMLEdit] {
-        // §7 will implement per-case logic. Returning empty is intentional
-        // scaffold marker — naturality tests in §9 will fail on stubs, which
-        // is the correct signal that implementation is pending.
-        []
+        switch self {
+
+        case .applyBold(let range):
+            // Single-Run case (startRun == endRun): 1:1 mapping to
+            // OOXMLEdit.setBold(target: startRun, value: true). The offsets
+            // are ignored at this layer — the OOXMLEdit applies bold to the
+            // ENTIRE run, not a substring. Partial-Run bold (offsets cover
+            // only part of the run's text) requires run-splitting, which is
+            // a separate OOXMLEdit case pending design (file ooxml-swift
+            // issue if needed).
+            if range.startRun == range.endRun {
+                return [.setBold(target: range.startRun, value: true)]
+            }
+            // Multi-Run / cross-paragraph case: lower() can't enumerate the
+            // runs between startRun and endRun without document context.
+            // Returning [] triggers the silent-noop guard in
+            // WordDocument.apply → throws notImplemented. Resolution
+            // requires either (a) Edit protocol amendment to pass doc to
+            // lower(), or (b) a pre-lower step that resolves the range to
+            // a list of (runID) on the document side. Tracked in macdoc#110.
+            return []
+
+        case .applyLink(let range, let url):
+            // Single-Run case: 1:1 to OOXMLEdit.insertHyperlink. Note that
+            // OOXMLEdit.insertHyperlink itself is STUBBED pending §5
+            // composite design checkpoint — calling doc.apply(applyLink)
+            // will throw notImplemented at the operations() step, not here.
+            // That's the correct error-surfacing layer.
+            //
+            // displayText: nil — lower() can't extract the substring from
+            // startRun.text[startOffset..<endOffset] without doc context.
+            // The §5 design will resolve nil → use href as displayed text,
+            // or require displayText to be passed explicitly by the caller.
+            if range.startRun == range.endRun {
+                return [.insertHyperlink(
+                    target: range.startRun,
+                    href: url,
+                    displayText: nil
+                )]
+            }
+            // Multi-Run case: same constraint as applyBold above.
+            return []
+
+        case .applyInsertParagraph(let after, let content):
+            // Simplest case: 1:1 mapping. ParagraphRef wraps an ElementID
+            // that's already in the right shape for OOXMLEdit.
+            return [.insertParagraph(
+                after: after.elementID,
+                content: content,
+                styleId: nil
+            )]
+        }
     }
 }

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/WordEditLowerTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/WordEditLowerTests.swift
@@ -1,0 +1,245 @@
+// WordEditLowerTests.swift
+// EditAlgebra — addresses macdoc#110 item #6 (§7 of macdoc#105 tasks.md).
+//
+// Per-case `WordEdit.lower() -> [OOXMLEdit]` translation tests, satisfying
+// the spec.md Requirement "WordEdit Enum with 3 Canonical Cases" lowering
+// contract and design.md Decision 2.
+//
+// Implemented:
+//   - applyBold(range:) — single-Run case
+//   - applyLink(range:url:) — single-Run case (lowered OOXMLEdit is itself
+//     stubbed pending §5 composite design)
+//   - applyInsertParagraph(after:content:) — trivial 1:1 mapping
+//
+// Cases that lower() can't resolve without document context return [] and
+// surface as `EditError.notImplemented` via the silent-noop guard in
+// `WordDocument.apply`. See WordEdit.swift for the bounded-context
+// constraint rationale.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class WordEditLowerTests: XCTestCase {
+
+    // MARK: - applyBold(range:) single-Run case
+
+    func testApplyBoldSingleRunLowersToSetBold() {
+        // startRun == endRun → 1:1 mapping to OOXMLEdit.setBold(target: startRun)
+        let runID = ElementID(libraryUUID: UUID())
+        let range = WordRange(
+            startRun: runID,
+            startOffset: 0,
+            endRun: runID,
+            endOffset: 5
+        )
+        let edit = WordEdit.applyBold(range: range)
+
+        let lowered = edit.lower()
+        XCTAssertEqual(lowered.count, 1, "single-Run applyBold lowers to exactly 1 OOXMLEdit")
+
+        guard case .setBold(let target, let value) = lowered[0] else {
+            XCTFail("Expected OOXMLEdit.setBold, got \(lowered[0])")
+            return
+        }
+        XCTAssertEqual(target, runID,
+                       "lowered setBold target == range.startRun (single-Run case)")
+        XCTAssertTrue(value, "lowered setBold value == true (applyBold always enables)")
+    }
+
+    func testApplyBoldSingleRunIgnoresOffsets() {
+        // Offsets are ignored at this layer — setBold applies to entire Run.
+        // Partial-Run bold (substring) would require run-splitting (separate
+        // OOXMLEdit case, tracked for future design).
+        let runID = ElementID(libraryUUID: UUID())
+        let range1 = WordRange(startRun: runID, startOffset: 0, endRun: runID, endOffset: 100)
+        let range2 = WordRange(startRun: runID, startOffset: 3, endRun: runID, endOffset: 7)
+
+        let lowered1 = WordEdit.applyBold(range: range1).lower()
+        let lowered2 = WordEdit.applyBold(range: range2).lower()
+
+        XCTAssertEqual(lowered1, lowered2,
+                       "Single-Run applyBold lowering ignores offsets (whole-Run mutation)")
+    }
+
+    // MARK: - applyBold(range:) multi-Run case (returns []) — surfaces via apply
+
+    func testApplyBoldMultiRunReturnsEmptyLower() {
+        // startRun != endRun → cross-Run case. lower() can't resolve
+        // intermediate Runs without doc context, so returns []. The empty
+        // list triggers the silent-noop guard in WordDocument.apply.
+        let startRunID = ElementID(libraryUUID: UUID())
+        let endRunID = ElementID(libraryUUID: UUID())
+        let range = WordRange(startRun: startRunID, startOffset: 0, endRun: endRunID, endOffset: 5)
+        let edit = WordEdit.applyBold(range: range)
+
+        XCTAssertEqual(edit.lower(), [],
+                       "Multi-Run applyBold.lower() returns [] (unsupported input combination)")
+    }
+
+    func testApplyBoldMultiRunSurfacesViaApply() {
+        // doc.apply(multiRunApplyBold) should throw notImplemented (the
+        // silent-noop guard in WordDocument.apply catches the empty lower()
+        // and throws with a clear message).
+        let doc = WordDocument()
+        let startRunID = ElementID(libraryUUID: UUID())
+        let endRunID = ElementID(libraryUUID: UUID())
+        let range = WordRange(startRun: startRunID, startOffset: 0, endRun: endRunID, endOffset: 5)
+        let edit = WordEdit.applyBold(range: range)
+
+        XCTAssertThrowsError(try doc.apply(edit)) { error in
+            guard case EditError.notImplemented(let message) = error else {
+                XCTFail("Expected .notImplemented, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("WordEdit"),
+                          "Error message references WordEdit type: \(message)")
+        }
+    }
+
+    // MARK: - applyLink(range:url:) single-Run case
+
+    func testApplyLinkSingleRunLowersToInsertHyperlink() {
+        let runID = ElementID(libraryUUID: UUID())
+        let url = URL(string: "https://example.com/test")!
+        let range = WordRange(startRun: runID, startOffset: 0, endRun: runID, endOffset: 5)
+        let edit = WordEdit.applyLink(range: range, url: url)
+
+        let lowered = edit.lower()
+        XCTAssertEqual(lowered.count, 1, "single-Run applyLink lowers to exactly 1 OOXMLEdit")
+
+        guard case .insertHyperlink(let target, let href, let displayText) = lowered[0] else {
+            XCTFail("Expected OOXMLEdit.insertHyperlink, got \(lowered[0])")
+            return
+        }
+        XCTAssertEqual(target, runID, "lowered insertHyperlink target == range.startRun")
+        XCTAssertEqual(href, url, "lowered insertHyperlink href == applyLink url")
+        XCTAssertNil(displayText,
+                     "displayText == nil (lower() can't extract substring without doc context; §5 design will resolve nil → use href)")
+    }
+
+    func testApplyLinkLoweredOOXMLEditStillStubbed() {
+        // The lowered OOXMLEdit.insertHyperlink is itself pending §5 design.
+        // doc.apply(applyLink) should throw notImplemented at the
+        // OOXMLEdit.operations() step, not at the WordEdit.lower() step.
+        // This test pins the layering: WordEdit.lower() works; OOXMLEdit
+        // path throws.
+        let doc = WordDocument()
+        let runID = ElementID(libraryUUID: UUID())
+        let url = URL(string: "https://example.com")!
+        let range = WordRange(startRun: runID, startOffset: 0, endRun: runID, endOffset: 5)
+        let edit = WordEdit.applyLink(range: range, url: url)
+
+        XCTAssertThrowsError(try doc.apply(edit)) { error in
+            guard case EditError.notImplemented(let message) = error else {
+                XCTFail("Expected .notImplemented from OOXMLEdit.insertHyperlink, got \(error)")
+                return
+            }
+            // The error originates from OOXMLEdit.operations() for insertHyperlink,
+            // not from WordEdit.lower(). Message should reference §5 (the
+            // OOXMLEdit stub) not §7 (the WordEdit lower stub).
+            XCTAssertTrue(message.contains("insertHyperlink") || message.contains("§5"),
+                          "Error from OOXMLEdit layer (§5), not WordEdit layer (§7): \(message)")
+        }
+    }
+
+    // MARK: - applyInsertParagraph(after:content:) — trivial 1:1
+
+    func testApplyInsertParagraphLowersToInsertParagraph() {
+        let paraID = ElementID(libraryUUID: UUID())
+        let paraRef = ParagraphRef(paraID)
+        let edit = WordEdit.applyInsertParagraph(after: paraRef, content: "Hello world")
+
+        let lowered = edit.lower()
+        XCTAssertEqual(lowered.count, 1)
+
+        guard case .insertParagraph(let after, let content, let styleId) = lowered[0] else {
+            XCTFail("Expected OOXMLEdit.insertParagraph, got \(lowered[0])")
+            return
+        }
+        XCTAssertEqual(after, paraID, "after: ParagraphRef → ElementID round-trip")
+        XCTAssertEqual(content, "Hello world")
+        XCTAssertNil(styleId, "WordEdit.applyInsertParagraph doesn't take styleId; lowered styleId == nil")
+    }
+
+    func testApplyInsertParagraphEmptyContent() {
+        // Pin: empty content is legal (creates empty paragraph)
+        let paraRef = ParagraphRef(ElementID(libraryUUID: UUID()))
+        let edit = WordEdit.applyInsertParagraph(after: paraRef, content: "")
+
+        let lowered = edit.lower()
+        guard case .insertParagraph(_, let content, _) = lowered[0] else {
+            XCTFail("Expected OOXMLEdit.insertParagraph")
+            return
+        }
+        XCTAssertEqual(content, "", "Empty content propagates through lower()")
+    }
+
+    // MARK: - End-to-end: WordEdit chains through to xmlTrees mutation
+
+    func testApplyInsertParagraphEndToEndMutatesDocPart() throws {
+        // The full path: WordEdit.applyInsertParagraph → lower() →
+        // OOXMLEdit.insertParagraph → operations() → log append → materialize
+        // → xmlTrees mutation. This is the first proof that WordEdit is
+        // production-ready for at least one case.
+        let paraUUID = UUID()
+        let textNode = XmlNode.text("first")
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+        let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+        wp.libraryUUID = paraUUID
+        let body = XmlNode.element(prefix: "w", localName: "body", children: [wp])
+        let root = XmlNode.element(prefix: "w", localName: "document", children: [body])
+
+        var doc = WordDocument()
+        doc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: root)
+
+        let paraRef = ParagraphRef(ElementID(libraryUUID: paraUUID))
+        let edit = WordEdit.applyInsertParagraph(after: paraRef, content: "second")
+        let result = try doc.apply(edit)
+
+        // Walk result's body and verify second paragraph appears
+        var texts: [String] = []
+        func walk(_ node: XmlNode) {
+            if node.kind == .element && node.localName == "t" {
+                for child in node.children where child.kind == .text {
+                    texts.append(child.textContent)
+                }
+            }
+            for child in node.children { walk(child) }
+        }
+        walk(result.xmlTrees["word/document.xml"]!.root)
+        XCTAssertEqual(texts, ["first", "second"],
+                       "WordEdit.applyInsertParagraph end-to-end produces new paragraph in doc")
+    }
+
+    func testApplyBoldSingleRunEndToEndMutatesRPr() throws {
+        // applyBold single-Run case lowers to setBold which has a working
+        // reducer. End-to-end proves WordEdit ergonomics work for this case.
+        let runUUID = UUID()
+        let textNode = XmlNode.text("hello")
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+        wr.libraryUUID = runUUID
+        let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+        let body = XmlNode.element(prefix: "w", localName: "body", children: [wp])
+        let root = XmlNode.element(prefix: "w", localName: "document", children: [body])
+
+        var doc = WordDocument()
+        doc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: root)
+
+        let runID = ElementID(libraryUUID: runUUID)
+        let range = WordRange(startRun: runID, startOffset: 0, endRun: runID, endOffset: 5)
+        let edit = WordEdit.applyBold(range: range)
+        let result = try doc.apply(edit)
+
+        // Verify <w:b/> appeared in target Run's rPr
+        guard let tree = result.xmlTrees["word/document.xml"],
+              let run = OperationReducer.findNode(elementID: runID, in: tree),
+              let rPr = run.children.first(where: { $0.kind == .element && $0.localName == "rPr" }) else {
+            XCTFail("Expected run with rPr after applyBold")
+            return
+        }
+        let hasBold = rPr.children.contains { $0.kind == .element && $0.localName == "b" }
+        XCTAssertTrue(hasBold, "applyBold end-to-end produces <w:b/> in target Run's rPr")
+    }
+}


### PR DESCRIPTION
## Summary

Fourth slice of [macdoc#110](https://github.com/PsychQuant/macdoc/issues/110) — implements per-case `WordEdit.lower()` for all 3 cases, satisfying [macdoc#105 spec.md](https://github.com/PsychQuant/macdoc/blob/main/openspec/changes/ooxml-edit-algebra-implementation/specs/ooxml-edit-algebra-runtime/spec.md) Requirement "WordEdit Enum with 3 Canonical Cases" lowering contract + [design.md Decision 2](https://github.com/PsychQuant/macdoc/blob/main/openspec/changes/ooxml-edit-algebra-implementation/design.md).

## Per-case implementations

### `applyBold(range:)` 

| Input | Lower output | End-to-end status |
|---|---|---|
| Single-Run (startRun == endRun) | `[OOXMLEdit.setBold(target: startRun, value: true)]` | ✓ Functional through reducer |
| Multi-Run / cross-paragraph | `[]` | Throws `notImplemented` at apply (silent-noop guard) |

Offsets ignored at this layer — `setBold` applies to entire Run. Partial-Run bold (substring) requires run-splitting (separate OOXMLEdit case, not in current scope).

### `applyLink(range:url:)` 

| Input | Lower output | End-to-end status |
|---|---|---|
| Single-Run | `[OOXMLEdit.insertHyperlink(target: startRun, href: url, displayText: nil)]` | Throws `notImplemented` at OOXMLEdit layer (§5 pending) |
| Multi-Run | `[]` | Throws `notImplemented` at apply |

Correct layering: `WordEdit.lower()` works; the throw originates from `OOXMLEdit.operations()` for `insertHyperlink` (§5 design checkpoint pending), NOT from `WordEdit.lower()`. Test `testApplyLinkLoweredOOXMLEditStillStubbed` pins this.

### `applyInsertParagraph(after:content:)`

| Input | Lower output | End-to-end status |
|---|---|---|
| All | `[OOXMLEdit.insertParagraph(after: paraRef.elementID, content: content, styleId: nil)]` | ✓ Functional through reducer |

Simplest case — trivial 1:1 mapping. `ParagraphRef` wraps an `ElementID` that's already in the right shape for `OOXMLEdit`.

## Why empty-list (`[]`) for multi-Run cases

`Edit.lower()` is non-throwing + takes no document context per the protocol. The multi-Run / cross-paragraph case can't resolve intermediate Runs without doc access. Returning `[]` triggers the existing silent-noop guard in `WordDocument.apply` → throws `notImplemented` with a clear message:

> "Edit of type WordEdit returned empty lower(). Either the case is not yet implemented (see macdoc#110 / macdoc#105 §7), or the input combination requires document context that the non-throwing no-arg lower() protocol can't access (e.g., cross-paragraph WordRange)."

Updated guard message (was: "likely a stub case. Per-case WordEdit.lower() implementations land in §7") to cover both unimplemented-stub AND unsupported-input scenarios. The check itself stays — multi-Run cases of applyBold and applyLink legitimately need it.

Resolution paths (future work):
- (a) Amend `Edit` protocol to pass doc to `lower()` (breaks protocol cleanliness)
- (b) Pre-lower step that resolves WordRange to list of (runID) on the document side
- (c) Add document-context-aware overload `lower(in: WordDocument)` alongside the no-arg version

Out of scope for this PR.

## What this unblocks

**§9 NaturalityTests** is now PARTIALLY unblocked:
- `applyBold ∘ applyInsertParagraph` — both single-Run lower() work → naturality pair testable
- `applyBold ∘ applyLink` — applyLink lowers but throws at OOXMLEdit step → naturality assertion needs special handling
- `applyLink ∘ applyInsertParagraph` — same as above

When §5 ships, the remaining 2 pair-types become fully testable.

## Test plan

11 new tests in `WordEditLowerTests.swift`:

| Test | Pins |
|---|---|
| `testApplyBoldSingleRunLowersToSetBold` | Single-Run emission shape |
| `testApplyBoldSingleRunIgnoresOffsets` | Offsets ignored (whole-Run mutation) |
| `testApplyBoldMultiRunReturnsEmptyLower` | Multi-Run returns [] |
| `testApplyBoldMultiRunSurfacesViaApply` | Empty lower() → apply throws notImplemented |
| `testApplyLinkSingleRunLowersToInsertHyperlink` | Single-Run emission shape |
| `testApplyLinkLoweredOOXMLEditStillStubbed` | Throw originates at OOXMLEdit layer, NOT WordEdit layer (§5 vs §7) |
| `testApplyInsertParagraphLowersToInsertParagraph` | Trivial 1:1 mapping |
| `testApplyInsertParagraphEmptyContent` | Empty content propagates |
| `testApplyInsertParagraphEndToEndMutatesDocPart` | Full chain WordEdit → xmlTrees mutation |
| `testApplyBoldSingleRunEndToEndMutatesRPr` | Full chain → `<w:b/>` in rPr |

Full ooxml-swift suite: **1055 pass / 2 skipped / 0 fail** (was 1045 +10 from new tests; net +10 because the existing `testApplyThrowsOnStubWordEditEmptyLower` still passes against the broadened error message).

## Remaining macdoc#110 work (4 items remain)

| # | Item | Status |
|---|---|---|
| 1 | FullyFaithfulFunctorTests | ✓ DONE |
| 2 | NaturalityTests | Partially unblocked (this PR ships §7 lower()) |
| 3 | CD diagrams | ✓ DONE |
| 4 | Performance benchmark | TODO |
| 5 | §5 insertHyperlink composite | TODO (pending design checkpoint) |
| 6 | §7 WordEdit.lower() per-case | **✓ DONE (this PR)** |
| 7 | Multi-part scoping fix | ✓ DONE |
| 8 | Stale typed-views resync | TODO |
| 9 | Stub-cascade cleanup | TODO (depends on §5) |

5 of 9 items closed.

Refs PsychQuant/macdoc#110
Refs PsychQuant/macdoc#105
