### PR TITLE
feat(EditAlgebra): item #8 typed-views resync (opt-in) (macdoc#110)

### DIFF
--- a/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
@@ -139,14 +139,85 @@ extension WordDocument {
         }
 
         // 5. Construct new WordDocument with updated log + trees.
-        //    Typed views (body/styles/etc.) carried over from self — STALE
-        //    relative to new xmlTrees. Resync tracked as item #8 of
-        //    macdoc#110 (SEPARATE from the multi-part scoping fix shipped
-        //    here — don't conflate them when chasing #110).
+        //    body.children typed view is NOT auto-resynced — calling
+        //    resync would create new Paragraph(xmlNode:) instances whose
+        //    xmlNode references are different from any other path's
+        //    deep-copied tree, breaking the reference-equality Paragraph
+        //    Equatable (which downstream comparisons like Naturality tests
+        //    depend on). Callers who need a fresh body.children call
+        //    `newDocument.resyncBodyFromDocumentTree()` explicitly.
+        //
+        //    Per macdoc#110 item #8: the resync mechanism ships here as
+        //    opt-in. Future architectural work (content-based Paragraph
+        //    Equatable, or always-tree-backed Paragraph that re-reads on
+        //    every access) could enable auto-resync — out of scope here.
         var newDocument = self
         newDocument.operationLog = newLog
         newDocument.xmlTrees = newTrees
         return newDocument
+    }
+
+    /// Rebuilds `body.children` from the current `xmlTrees["word/document.xml"]`
+    /// tree. Walks the `<w:body>` direct children and constructs tree-backed
+    /// `Paragraph(xmlNode:)` / `Table(xmlNode:)` values. Non-paragraph /
+    /// non-table body elements are dropped from the typed view (see scope
+    /// notes below).
+    ///
+    /// **Opt-in design**: this method is NOT called automatically by
+    /// `apply()` because tree-backed Paragraph uses reference equality
+    /// (`Paragraph.==` compares `xmlNode === xmlNode`). Auto-resync after
+    /// apply would create new XmlNode instances on every apply call,
+    /// breaking downstream equality comparisons (notably NaturalityTests
+    /// which assert two apply paths produce equal docs). Callers who want
+    /// fresh body.children after apply call this method explicitly.
+    ///
+    /// **Narrow scope** (documented limitations):
+    /// - Only `<w:p>` and `<w:tbl>` become typed body children. Other
+    ///   body-level elements (`<w:sdt>`, `<w:bookmarkStart>`/End, vendor
+    ///   extensions) are NOT re-typed; they remain in xmlTrees but
+    ///   disappear from body.children. If your doc has these and you
+    ///   rely on body.children to round-trip them, prefer reading from
+    ///   xmlTrees directly.
+    /// - Only document.xml's body is resynced. styles, headers, footers,
+    ///   numbering, footnotes, endnotes remain stale relative to new
+    ///   xmlTrees.
+    ///
+    /// Safe to call multiple times — each call rebuilds from scratch.
+    ///
+    /// macdoc#110 item #8 tracker. Full auto-resync would require a
+    /// downstream refactor of Paragraph Equatable semantics (out of
+    /// scope here).
+    public mutating func resyncBodyFromDocumentTree() {
+        guard let docTree = self.xmlTrees["word/document.xml"] else { return }
+        guard let bodyNode = docTree.root.children.first(where: {
+            $0.kind == .element && $0.localName == "body"
+        }) else { return }
+
+        var newChildren: [BodyChild] = []
+        var newTables: [Table] = []
+
+        for child in bodyNode.children where child.kind == .element {
+            switch child.localName {
+            case "p":
+                newChildren.append(.paragraph(Paragraph(xmlNode: child)))
+            case "tbl":
+                let t = Table(xmlNode: child)
+                newChildren.append(.table(t))
+                newTables.append(t)
+            case "sectPr":
+                // Parsed separately into sectionProperties; skip from body
+                continue
+            default:
+                // Other body-level elements (sdt, bookmarkMarker, vendor
+                // extensions) are not currently re-typed by apply(). They
+                // remain in xmlTrees for byte-equivalent round-trip but
+                // disappear from body.children typed view. See scope notes.
+                continue
+            }
+        }
+
+        self.body.children = newChildren
+        self.body.tables = newTables
     }
 
     /// Apply a sequence of Edits in order, folding each result into the next

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/TypedViewResyncTests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/TypedViewResyncTests.swift
@@ -1,0 +1,186 @@
+// TypedViewResyncTests.swift
+// EditAlgebra — addresses macdoc#110 item #8.
+//
+// After WordDocument.apply(_:), the typed views (body, styles, etc.) were
+// stale relative to the new xmlTrees. Callers reading result.body.children
+// would see PRE-edit content even though xmlTrees was correctly mutated.
+//
+// This PR fixes body.children specifically: it's rebuilt from the new
+// document.xml tree after apply, with each <w:p> and <w:tbl> becoming a
+// tree-backed Paragraph(xmlNode:) / Table(xmlNode:).
+//
+// Limitations (documented in WordDocument+Apply.swift):
+//   - Only <w:p> and <w:tbl> become typed body children. Other body-level
+//     elements (<w:sdt>, <w:bookmarkStart>/End, etc.) are NOT re-typed.
+//   - Only document.xml's body is resynced. styles/headers/footers/etc.
+//     remain stale after apply.
+//
+// Tests cover the working scope: body.children paragraph resync for the
+// 4 functional OOXMLEdit cases.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class TypedViewResyncTests: XCTestCase {
+
+    // MARK: - Helpers (single-part doc with N paragraphs)
+
+    private func makeFixture(paragraphs texts: [String]) -> (WordDocument, [ElementID]) {
+        var paraIDs: [ElementID] = []
+        var paragraphNodes: [XmlNode] = []
+
+        for text in texts {
+            let paraUUID = UUID()
+            paraIDs.append(ElementID(libraryUUID: paraUUID))
+
+            let textNode = XmlNode.text(text)
+            let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+            let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+            let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+            wp.libraryUUID = paraUUID
+            paragraphNodes.append(wp)
+        }
+
+        let body = XmlNode.element(prefix: "w", localName: "body", children: paragraphNodes)
+        let root = XmlNode.element(prefix: "w", localName: "document", children: [body])
+
+        var doc = WordDocument()
+        doc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: root)
+        // Note: body.children is EMPTY before resync. The fixture doesn't
+        // populate it from the synthesized tree — that's what resync does.
+        return (doc, paraIDs)
+    }
+
+    /// Extracts body.children text contents in order. Returns nil for non-Paragraph entries.
+    private func bodyParagraphTexts(_ doc: WordDocument) -> [String] {
+        return doc.body.children.compactMap { child -> String? in
+            guard case .paragraph(let p) = child else { return nil }
+            return p.text
+        }
+    }
+
+    // MARK: - insertParagraph resyncs body.children
+
+    func testInsertParagraphResyncsBody() throws {
+        let (doc, paraIDs) = makeFixture(paragraphs: ["first"])
+
+        // Sanity: pre-apply, body.children is empty (fixture didn't populate it)
+        XCTAssertEqual(doc.body.children.count, 0,
+                       "Synthesized fixture has empty body.children pre-apply (unset)")
+
+        let edit = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "second", styleId: nil)
+        var result = try doc.apply(edit)
+        result.resyncBodyFromDocumentTree()
+
+        // Post-apply + resync: body.children has 2 paragraphs (existing + new)
+        XCTAssertEqual(bodyParagraphTexts(result), ["first", "second"],
+                       "After insertParagraph apply + resync, body.children reflects new paragraph")
+    }
+
+    func testInsertParagraphBeforeResyncsBody() throws {
+        let (doc, paraIDs) = makeFixture(paragraphs: ["second"])
+
+        let edit = OOXMLEdit.insertParagraphBefore(before: paraIDs[0], content: "first", styleId: nil)
+        var result = try doc.apply(edit)
+        result.resyncBodyFromDocumentTree()
+
+        XCTAssertEqual(bodyParagraphTexts(result), ["first", "second"],
+                       "After insertParagraphBefore apply + resync, body.children reflects new paragraph at start")
+    }
+
+    // MARK: - removeParagraph resyncs body.children
+
+    func testRemoveParagraphResyncsBody() throws {
+        let (doc, paraIDs) = makeFixture(paragraphs: ["a", "b", "c"])
+
+        let edit = OOXMLEdit.removeParagraph(target: paraIDs[1])  // remove "b"
+        var result = try doc.apply(edit)
+        result.resyncBodyFromDocumentTree()
+
+        XCTAssertEqual(bodyParagraphTexts(result), ["a", "c"],
+                       "After removeParagraph apply + resync, body.children reflects removal")
+    }
+
+    // MARK: - setBold doesn't change paragraph count but reflects new run state
+
+    func testSetBoldResyncsBodyContent() throws {
+        let (doc, paraIDs) = makeFixture(paragraphs: ["hello"])
+
+        // Get the run ID inside the first paragraph's <w:r>
+        let tree = doc.xmlTrees["word/document.xml"]!
+        let bodyNode = tree.root.children.first { $0.kind == .element && $0.localName == "body" }!
+        let firstP = bodyNode.children.first { $0.kind == .element && $0.localName == "p" }!
+        let firstR = firstP.children.first { $0.kind == .element && $0.localName == "r" }!
+        // The fixture run doesn't have a libraryUUID, so set one for addressing
+        let runUUID = UUID()
+        firstR.libraryUUID = runUUID
+        let runID = ElementID(libraryUUID: runUUID)
+
+        let edit = OOXMLEdit.setBold(target: runID, value: true)
+        var result = try doc.apply(edit)
+        result.resyncBodyFromDocumentTree()
+
+        // body still has 1 paragraph
+        XCTAssertEqual(result.body.children.count, 1, "Paragraph count unchanged after setBold + resync")
+
+        // The paragraph IS tree-backed (xmlNode wired) so reads reflect new state
+        guard case .paragraph(let p) = result.body.children[0] else {
+            XCTFail("Expected paragraph in body.children[0]")
+            return
+        }
+        XCTAssertNotNil(p.xmlNode, "Resync produces tree-backed paragraph (xmlNode != nil)")
+        XCTAssertEqual(p.text, "hello", "Paragraph text unchanged by setBold")
+
+        // The run inside should now have <w:b/> in rPr (verify via xmlNode walk)
+        guard let pNode = p.xmlNode,
+              let rNode = pNode.children.first(where: { $0.kind == .element && $0.localName == "r" }),
+              let rPr = rNode.children.first(where: { $0.kind == .element && $0.localName == "rPr" }) else {
+            XCTFail("Expected rPr in paragraph's run after setBold")
+            return
+        }
+        let hasBold = rPr.children.contains { $0.kind == .element && $0.localName == "b" }
+        XCTAssertTrue(hasBold, "Resynced paragraph's run has <w:b/> in rPr (post-edit state)")
+    }
+
+    // MARK: - resync produces tree-backed paragraphs (xmlNode != nil)
+
+    func testResyncProducesTreeBackedParagraphs() throws {
+        let (doc, paraIDs) = makeFixture(paragraphs: ["one", "two"])
+
+        let edit = OOXMLEdit.insertParagraph(after: paraIDs[1], content: "three", styleId: nil)
+        var result = try doc.apply(edit)
+        result.resyncBodyFromDocumentTree()
+
+        XCTAssertEqual(result.body.children.count, 3)
+        for (i, child) in result.body.children.enumerated() {
+            guard case .paragraph(let p) = child else {
+                XCTFail("body.children[\(i)] should be a paragraph")
+                continue
+            }
+            XCTAssertNotNil(p.xmlNode,
+                            "body.children[\(i)] should be tree-backed (xmlNode != nil) after apply resync")
+        }
+    }
+
+    // MARK: - Sequence apply preserves resync at each step
+
+    func testSequenceApplyResyncsBodyAtEachStep() throws {
+        let (doc, paraIDs) = makeFixture(paragraphs: ["x"])
+
+        let edit1 = OOXMLEdit.insertParagraph(after: paraIDs[0], content: "y", styleId: nil)
+        var intermediate = try doc.apply(edit1)
+        intermediate.resyncBodyFromDocumentTree()
+        XCTAssertEqual(bodyParagraphTexts(intermediate), ["x", "y"],
+                       "After first apply + resync, body has 2 paragraphs")
+
+        // Use the inserted "y"'s opID to chain a subsequent insert after it
+        let yOpID = intermediate.operationLog.entries.last!.opID
+        let yID = ElementID(libraryUUID: yOpID)
+        let edit2 = OOXMLEdit.insertParagraph(after: yID, content: "z", styleId: nil)
+        var final = try intermediate.apply(edit2)
+        final.resyncBodyFromDocumentTree()
+
+        XCTAssertEqual(bodyParagraphTexts(final), ["x", "y", "z"],
+                       "After sequence apply + resync, body reflects chained insertions")
+    }
+}


### PR DESCRIPTION
## Summary

Seventh slice of [macdoc#110](https://github.com/PsychQuant/macdoc/issues/110) — ships the body.children resync mechanism (item #8) as an **opt-in** method rather than automatic. Architectural constraint forced the opt-in approach; documented below.

## What ships

```swift
public mutating func WordDocument.resyncBodyFromDocumentTree()
```

Rebuilds `body.children` from the current `xmlTrees["word/document.xml"]` tree. Walks `<w:body>` direct children and constructs tree-backed `Paragraph(xmlNode:)` / `Table(xmlNode:)` values.

Usage:
```swift
var result = try doc.apply(edit)
result.resyncBodyFromDocumentTree()  // opt-in
// Now result.body.children reflects post-edit content
```

## Why opt-in (architectural constraint)

Initial implementation auto-called resync at the end of `apply()`. That broke 102 tests including ALL NaturalityTests because:

> `Paragraph.Equatable` in tree-backed mode compares xmlNode by **REFERENCE** (`a === b`), per existing design at [`Paragraph.swift:294-303`](../blob/main/Sources/OOXMLSwift/Models/Paragraph.swift#L294-L303).

Each `apply()` call deep-copies the tree via `OperationReducer.materialize`, so two apply paths produce different XmlNode instances → resynced Paragraphs compare unequal → cascading equality failures.

`NaturalityTests` specifically assert `doc.apply(a).apply(b) == doc.apply([a, b])`. Both paths go through `apply` with auto-resync, producing docs with reference-distinct xmlNodes in body.children → the equality assertion fails despite content being identical.

## Resolution paths considered

| Approach | Verdict |
|---|---|
| Change `Paragraph` Equatable to content-based | Out of scope — touches many call sites that depend on reference identity semantics |
| Mark body.children as 'don't compare' in `WordDocument.==` | Special case in custom Equatable; opaque and fragile |
| Auto-resync via WordEdit-level flag | Leaks abstraction |
| **Make resync opt-in (this PR)** | **CHOSEN** — caller controls when to refresh body; default apply behavior unchanged → zero regressions |

The apply() code now has an explicit comment block explaining why body isn't auto-resynced + pointers to the opt-in helper. Full auto-resync would require downstream `Paragraph` Equatable refactor (separate work, not blocking).

## Scope notes (documented in code)

- Only `<w:p>` and `<w:tbl>` get re-typed as Paragraph/Table. Other body-level elements (`<w:sdt>`, `<w:bookmarkStart>`/End, vendor extensions) are dropped from typed view but PRESERVED in xmlTrees for byte-equivalent round-trip.
- Only document.xml's body is resynced. styles/headers/footers/numbering/footnotes/endnotes remain stale relative to new xmlTrees.

## Test plan

6 new tests in `TypedViewResyncTests.swift`:

| Test | Pins |
|---|---|
| `testInsertParagraphResyncsBody` | After apply + resync: body has +1 paragraph in correct position |
| `testInsertParagraphBeforeResyncsBody` | Symmetric (paragraph at start) |
| `testRemoveParagraphResyncsBody` | After apply + resync: body has -1 paragraph; siblings preserved |
| `testSetBoldResyncsBodyContent` | Paragraph count unchanged; tree-backed paragraph reads `<w:b/>` from rPr |
| `testResyncProducesTreeBackedParagraphs` | All paragraphs have `xmlNode != nil` post-resync |
| `testSequenceApplyResyncsBodyAtEachStep` | Chained applies with resync at each step produce correct cumulative body |

Full ooxml-swift suite: **1067 pass / 2 skipped / 0 fail**. Zero regressions vs main.

## Remaining macdoc#110 work

Closing item #8 leaves **2 items in #110**:
- §5 insertHyperlink composite (blocked on user design checkpoint)
- Stub-cascade cleanup (depends on §5)

Both are gated by §5. Effectively #110 is at "maximally closed without §5 design input".

## Architectural follow-up (NOT this PR)

A separate change could enable auto-resync by:
1. Adding a content-based equality mode to Paragraph (perhaps `==-content`)
2. Or: making body.children always-tree-backed (re-read on every access, no cache)
3. Or: structural Paragraph identity (UUID-based) instead of reference

Each option has its own design trade-offs; none are blocking the current architecture. File a follow-up issue when motivated.

Refs PsychQuant/macdoc#110
Refs PsychQuant/macdoc#105
