### PR TITLE
feat(OpLog/Phase 2c): insertSiblingAfter + addRelationship reducers — unblocks OOXMLEdit.insertHyperlink end-to-end (#71)

### DIFF
--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
@@ -58,16 +58,16 @@ extension OOXMLEdit {
             // Insert semantics: new <w:hyperlink> wrapper appended as
             // sibling after target. Allocate a fresh rId for the rels
             // entry. Per Q4 of §5 walkthrough: nil displayText → href.absoluteString.
+            //
+            // Updated in ooxml-swift#71 Phase 2c: uses the new typed
+            // Operation.insertSiblingAfter primitive (was insertNode with
+            // position=-1 sentinel, which was semantically incorrect since
+            // target is the previous-sibling reference, not the parent).
             let rId = freshRelationshipId()
             let display = displayText ?? href.absoluteString
             let hyperlinkXML = renderHyperlinkXML(rId: rId, displayText: display)
-            // Position 0 is overridden during apply when the Reducer
-            // materializes — the reducer's insertNode case computes the
-            // sibling-after-target position. (Position field is a Phase 2c
-            // refinement; for now we use a sentinel that the reducer
-            // interprets as "after target".)
             return [
-                .insertNode(parent: target, position: -1, nodeXML: hyperlinkXML),
+                .insertSiblingAfter(after: target, nodeXML: hyperlinkXML),
                 .addRelationship(
                     part: documentRelsPath,
                     id: rId,

--- a/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/WordDocument+Apply.swift
@@ -105,7 +105,18 @@ extension WordDocument {
 
         for (op, opID) in zip(newOps, opIDs) {
             let partPath: String
-            if let single = singlePartPath {
+
+            // Part-addressed ops (addRelationship) carry their target part
+            // path in the payload — route directly without partContaining
+            // walk. addRelationship needs the rels part tree to exist; if
+            // not, we create it on-demand (rels parts often don't exist
+            // in synthesized fixtures).
+            if case .addRelationship(let part, _, _, _, _) = op {
+                partPath = part
+                if newTrees[part] == nil {
+                    newTrees[part] = makeEmptyRelationshipsTree()
+                }
+            } else if let single = singlePartPath {
                 partPath = single
             } else {
                 guard let found = OperationReducer.partContaining(op: op, in: newTrees) else {
@@ -155,6 +166,22 @@ extension WordDocument {
         newDocument.operationLog = newLog
         newDocument.xmlTrees = newTrees
         return newDocument
+    }
+
+    /// Constructs an empty `<Relationships>` XmlTree suitable for
+    /// addRelationship operations. Used when apply() encounters an
+    /// addRelationship op on a doc whose rels part doesn't exist yet
+    /// (common in synthesized fixtures).
+    ///
+    /// The namespace `http://schemas.openxmlformats.org/package/2006/relationships`
+    /// is the standard rels-part namespace per ECMA-376.
+    internal func makeEmptyRelationshipsTree() -> XmlTree {
+        let root = XmlNode.element(
+            prefix: nil,
+            localName: "Relationships",
+            namespaceURI: "http://schemas.openxmlformats.org/package/2006/relationships"
+        )
+        return XmlTree.synthesized(root: root)
     }
 
     /// Rebuilds `body.children` from the current `xmlTrees["word/document.xml"]`

--- a/Sources/OOXMLSwift/OpLog/Operation.swift
+++ b/Sources/OOXMLSwift/OpLog/Operation.swift
@@ -48,6 +48,20 @@ public enum Operation: Equatable, Sendable {
     case updateAttribute(target: ElementID, prefix: String?, localName: String, value: String?)
     case moveNode(source: ElementID, destinationParent: ElementID, destinationIndex: Int)
 
+    /// Inserts a new XML node as the next sibling of `after` (i.e., into
+    /// after's parent at after's index + 1). Cleaner primitive than
+    /// `insertNode` for sibling-relative insertion — caller doesn't need
+    /// to resolve the parent and position; Reducer walks the tree to find
+    /// after's parent and computes the index.
+    ///
+    /// Used by `OOXMLEdit.insertHyperlink` to insert the `<w:hyperlink>`
+    /// wrapper after a target Run, and other "after X" sibling insertions
+    /// where the caller has the sibling ID but not the parent ID.
+    ///
+    /// `nodeXML` is parsed at Reducer time (via XmlTreeReader on a
+    /// fragment wrapped with namespace declarations).
+    case insertSiblingAfter(after: ElementID, nodeXML: String)
+
     // MARK: Rels-part operations (typed)
 
     /// Adds a `<Relationship Id="..." Type="..." Target="..." TargetMode="..."/>`

--- a/Sources/OOXMLSwift/OpLog/OperationLog+JSONL.swift
+++ b/Sources/OOXMLSwift/OpLog/OperationLog+JSONL.swift
@@ -230,6 +230,11 @@ internal enum JSONLLineCoder {
                 ("destinationParent", jsonString(destinationParent.raw)),
                 ("destinationIndex", String(destinationIndex))
             ])
+        case .insertSiblingAfter(let after, let nodeXML):
+            return ("insertSiblingAfter", [
+                ("after", jsonString(after.raw)),
+                ("nodeXML", jsonString(nodeXML))
+            ])
         case .addRelationship(let part, let id, let type, let target, let targetMode):
             return ("addRelationship", [
                 ("part", jsonString(part)),
@@ -340,6 +345,8 @@ internal enum JSONLLineCoder {
             )
         case "moveNode":
             return .moveNode(source: try eid("source"), destinationParent: try eid("destinationParent"), destinationIndex: try int("destinationIndex"))
+        case "insertSiblingAfter":
+            return .insertSiblingAfter(after: try eid("after"), nodeXML: try str("nodeXML"))
         case "addRelationship":
             return .addRelationship(
                 part: try str("part"),

--- a/Sources/OOXMLSwift/OpLog/OperationReducer.swift
+++ b/Sources/OOXMLSwift/OpLog/OperationReducer.swift
@@ -262,12 +262,60 @@ public enum OperationReducer {
              .insertRun,
              .insertBookmark, .insertComment,
              .redo,
-             .insertNode, .removeNode, .updateAttribute, .moveNode,
-             .addRelationship:
+             .insertNode, .removeNode, .updateAttribute, .moveNode:
             throw ReducerError.malformedOp(
                 opID: entry.opID,
                 reason: "Phase 2c implements this op"
             )
+
+        case .insertSiblingAfter(let after, let nodeXML):
+            // Find target's parent + index, parse XML fragment, insert as
+            // next sibling. Used by OOXMLEdit.insertHyperlink to insert
+            // <w:hyperlink> wrapper after a Run.
+            guard let (parent, idx) = findParentAndIndex(targetID: after, in: tree.root) else {
+                throw ReducerError.elementNotFound(opID: entry.opID, elementID: after)
+            }
+            do {
+                let newNode = try parseXMLFragment(nodeXML)
+                parent.children.insert(newNode, at: idx + 1)
+            } catch {
+                throw ReducerError.malformedOp(
+                    opID: entry.opID,
+                    reason: "Failed to parse insertSiblingAfter nodeXML: \(error.localizedDescription)"
+                )
+            }
+
+        case .addRelationship(let part, let id, let type, let target, let targetMode):
+            // Append a <Relationship> entry to the specified rels part.
+            // Rels-part xml has a fixed structure: <Relationships> root
+            // with <Relationship> children. We append to the root's
+            // children.
+            //
+            // The rels part is addressed by path, not ElementID — different
+            // from element-addressed ops. Reducer's `apply(entry:to:)`
+            // takes a single tree, but addRelationship needs to mutate
+            // a SPECIFIC rels tree. The caller (WordDocument.apply) must
+            // route this op to the rels part's tree before calling apply.
+            //
+            // Convention: when addRelationship is applied to a tree whose
+            // root is <Relationships>, we append. If the root isn't a
+            // relationships container, we throw — this is a routing error
+            // (caller passed wrong tree).
+            guard tree.root.kind == .element,
+                  tree.root.localName == "Relationships" else {
+                throw ReducerError.malformedOp(
+                    opID: entry.opID,
+                    reason: "addRelationship requires tree root to be <Relationships> element, got \(tree.root.localName); did caller route this op to the rels part? (part='\(part)')"
+                )
+            }
+            let rel = XmlNode.element(localName: "Relationship")
+            rel.setAttribute(prefix: nil, localName: "Id", value: id)
+            rel.setAttribute(prefix: nil, localName: "Type", value: type)
+            rel.setAttribute(prefix: nil, localName: "Target", value: target)
+            if let targetMode = targetMode {
+                rel.setAttribute(prefix: nil, localName: "TargetMode", value: targetMode)
+            }
+            tree.root.children.append(rel)
         }
     }
 
@@ -294,6 +342,45 @@ public enum OperationReducer {
             }
         }
         return nil
+    }
+
+    /// Parses an XML fragment string into an XmlNode by wrapping it in a
+    /// synthetic root with all common OOXML namespace declarations and
+    /// then stripping the synthetic root.
+    ///
+    /// Used by Phase 2c Reducer cases (insertSiblingAfter, insertNode)
+    /// to materialize the nodeXML payload into a real tree node.
+    ///
+    /// Throws if the fragment is malformed XML or doesn't contain exactly
+    /// one root element after parsing.
+    internal static func parseXMLFragment(_ fragment: String) throws -> XmlNode {
+        // Wrap the fragment in a synthetic root carrying common OOXML
+        // namespace declarations. XmlTreeReader requires a fully-formed
+        // document, so we synthesize one.
+        let wrappedXML =
+            "<__wrap__ " +
+            "xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" " +
+            "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" " +
+            "xmlns:w14=\"http://schemas.microsoft.com/office/word/2010/wordml\">" +
+            fragment +
+            "</__wrap__>"
+        guard let data = wrappedXML.data(using: .utf8) else {
+            throw NSError(
+                domain: "OperationReducer.parseXMLFragment",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to encode fragment as UTF-8"]
+            )
+        }
+        let tree = try XmlTreeReader.parse(data)
+        // The synthetic root's first element child IS the parsed fragment.
+        guard let parsed = tree.root.children.first(where: { $0.kind == .element }) else {
+            throw NSError(
+                domain: "OperationReducer.parseXMLFragment",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Fragment contained no element"]
+            )
+        }
+        return parsed
     }
 
     /// Sets or removes `<w:b/>` inside a `<w:r>`'s `<w:rPr>` to reflect the
@@ -457,6 +544,7 @@ public enum OperationReducer {
         case .removeNode(let target): return [target]
         case .updateAttribute(let target, _, _, _): return [target]
         case .moveNode(let source, let dest, _): return [source, dest]
+        case .insertSiblingAfter(let after, _): return [after]
         case .addRelationship:
             // Rels-part operations don't address an ElementID in any tree —
             // they target a part by path. WordDocument.apply's per-op
@@ -517,6 +605,7 @@ public enum OperationReducer {
         case .removeNode(let target): return target == elementID
         case .updateAttribute(let target, _, _, _): return target == elementID
         case .moveNode(let source, let dest, _): return source == elementID || dest == elementID
+        case .insertSiblingAfter(let after, _): return after == elementID
         case .addRelationship: return false  // rels-part operation, not element-addressed
         case .unknown: return false
         }

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertHyperlinkE2ETests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertHyperlinkE2ETests.swift
@@ -1,0 +1,173 @@
+// InsertHyperlinkE2ETests.swift
+// EditAlgebra — addresses ooxml-swift#71 Phase 2c reducer for
+// OOXMLEdit.insertHyperlink end-to-end mutation.
+//
+// After this PR ships Reducer support for:
+//   - Operation.insertSiblingAfter (new typed primitive)
+//   - Operation.addRelationship
+//
+// OOXMLEdit.insertHyperlink becomes functional end-to-end: doc.apply
+// produces a WordDocument whose xmlTrees["word/document.xml"] has the
+// <w:hyperlink> wrapper inserted after the target Run, and
+// xmlTrees["word/_rels/document.xml.rels"] has the new <Relationship>
+// entry.
+//
+// Wrap semantics (OOXMLEdit.wrapWithHyperlink) is NOT covered here —
+// the Reducer for wrapWithHyperlink (placeholder substitution or typed
+// wrap primitive) ships in a follow-up PR.
+
+import XCTest
+@testable import OOXMLSwift
+
+final class InsertHyperlinkE2ETests: XCTestCase {
+
+    // MARK: - Fixture
+
+    /// Builds a multi-part WordDocument:
+    ///   - word/document.xml: paragraph with one <w:r><w:t>before</w:t></w:r>
+    ///   - (no rels part initially — apply creates it on-demand)
+    /// Returns the doc + the target run's ElementID.
+    private func makeFixture() -> (WordDocument, ElementID) {
+        let runUUID = UUID()
+        let textNode = XmlNode.text("before")
+        let wt = XmlNode.element(prefix: "w", localName: "t", children: [textNode])
+        let wr = XmlNode.element(prefix: "w", localName: "r", children: [wt])
+        wr.libraryUUID = runUUID
+        let wp = XmlNode.element(prefix: "w", localName: "p", children: [wr])
+        let body = XmlNode.element(prefix: "w", localName: "body", children: [wp])
+        let root = XmlNode.element(prefix: "w", localName: "document", children: [body])
+
+        var doc = WordDocument()
+        doc.xmlTrees["word/document.xml"] = XmlTree.synthesized(root: root)
+        return (doc, ElementID(libraryUUID: runUUID))
+    }
+
+    // MARK: - End-to-end: insertHyperlink mutates both parts
+
+    func testInsertHyperlinkAddsWrapperAfterTargetRun() throws {
+        let (doc, runID) = makeFixture()
+        let url = URL(string: "https://example.com")!
+
+        let edit = OOXMLEdit.insertHyperlink(
+            target: runID,
+            href: url,
+            displayText: "click here"
+        )
+        let result = try doc.apply(edit)
+
+        // document.xml side: paragraph now has [run, hyperlink] in order
+        let docTree = result.xmlTrees["word/document.xml"]!
+        let body = docTree.root.children.first { $0.kind == .element && $0.localName == "body" }!
+        let para = body.children.first { $0.kind == .element && $0.localName == "p" }!
+
+        let paraChildren = para.children.filter { $0.kind == .element }
+        XCTAssertEqual(paraChildren.count, 2,
+                       "Paragraph has 2 element children: original run + hyperlink wrapper")
+        XCTAssertEqual(paraChildren[0].localName, "r",
+                       "First child is the original run")
+        XCTAssertEqual(paraChildren[1].localName, "hyperlink",
+                       "Second child is the new hyperlink wrapper")
+
+        // hyperlink wrapper contains a run with "click here"
+        let hyperlink = paraChildren[1]
+        let hyperlinkRId = hyperlink.attributeValue(prefix: "r", localName: "id")
+        XCTAssertNotNil(hyperlinkRId, "Hyperlink has r:id attribute")
+        XCTAssertTrue(hyperlinkRId?.hasPrefix("rIdEdit") ?? false,
+                      "rId follows freshRelationshipId convention: \(hyperlinkRId ?? "nil")")
+
+        let hyperlinkRun = hyperlink.children.first {
+            $0.kind == .element && $0.localName == "r"
+        }
+        XCTAssertNotNil(hyperlinkRun, "Hyperlink wraps one <w:r>")
+        let hyperlinkText = hyperlinkRun?.children.first {
+            $0.kind == .element && $0.localName == "t"
+        }?.children.first { $0.kind == .text }?.textContent
+        XCTAssertEqual(hyperlinkText, "click here", "Display text is 'click here'")
+    }
+
+    func testInsertHyperlinkCreatesRelsPartOnDemand() throws {
+        let (doc, runID) = makeFixture()
+        let url = URL(string: "https://example.com/test")!
+
+        // Sanity: rels part doesn't exist before apply
+        XCTAssertNil(doc.xmlTrees["word/_rels/document.xml.rels"],
+                     "Fixture has no rels part initially")
+
+        let edit = OOXMLEdit.insertHyperlink(target: runID, href: url, displayText: nil)
+        let result = try doc.apply(edit)
+
+        // rels part is created
+        let relsTree = result.xmlTrees["word/_rels/document.xml.rels"]
+        XCTAssertNotNil(relsTree, "Apply created rels part on-demand")
+        XCTAssertEqual(relsTree?.root.localName, "Relationships",
+                       "Rels part root is <Relationships>")
+
+        // Single <Relationship> child added
+        let relationships = relsTree?.root.children.filter {
+            $0.kind == .element && $0.localName == "Relationship"
+        } ?? []
+        XCTAssertEqual(relationships.count, 1, "One <Relationship> entry added")
+
+        // Attributes pin the contract
+        let rel = relationships[0]
+        XCTAssertEqual(rel.attributeValue(prefix: nil, localName: "Type"),
+                       "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink")
+        XCTAssertEqual(rel.attributeValue(prefix: nil, localName: "Target"),
+                       "https://example.com/test")
+        XCTAssertEqual(rel.attributeValue(prefix: nil, localName: "TargetMode"), "External")
+
+        // The Id attribute matches the hyperlink wrapper's r:id (referential integrity)
+        let docTree = result.xmlTrees["word/document.xml"]!
+        let para = docTree.root
+            .children.first { $0.kind == .element && $0.localName == "body" }!
+            .children.first { $0.kind == .element && $0.localName == "p" }!
+        let hyperlink = para.children.first { $0.kind == .element && $0.localName == "hyperlink" }!
+        let docRId = hyperlink.attributeValue(prefix: "r", localName: "id")
+        let relsId = rel.attributeValue(prefix: nil, localName: "Id")
+        XCTAssertEqual(docRId, relsId,
+                       "Hyperlink's r:id matches Relationship's Id (referential integrity)")
+    }
+
+    func testInsertHyperlinkNilDisplayTextFallsBackToHref() throws {
+        let (doc, runID) = makeFixture()
+        let url = URL(string: "https://example.com/x")!
+
+        let edit = OOXMLEdit.insertHyperlink(target: runID, href: url, displayText: nil)
+        let result = try doc.apply(edit)
+
+        // displayText nil → uses href as displayed text
+        let docTree = result.xmlTrees["word/document.xml"]!
+        let para = docTree.root
+            .children.first { $0.kind == .element && $0.localName == "body" }!
+            .children.first { $0.kind == .element && $0.localName == "p" }!
+        let hyperlink = para.children.first { $0.kind == .element && $0.localName == "hyperlink" }!
+        let displayText = hyperlink.children
+            .first { $0.kind == .element && $0.localName == "r" }?
+            .children.first { $0.kind == .element && $0.localName == "t" }?
+            .children.first { $0.kind == .text }?.textContent
+        XCTAssertEqual(displayText, "https://example.com/x",
+                       "Nil displayText falls back to href.absoluteString per §5 Q4 verdict")
+    }
+
+    // MARK: - WordEdit.applyLink stays gated on wrapWithHyperlink Reducer
+
+    func testApplyLinkStillThrowsAtWrapReducer() {
+        // WordEdit.applyLink lowers to OOXMLEdit.wrapWithHyperlink (per
+        // Design Y), whose Reducer support is NOT in this PR. End-to-end
+        // applyLink continues to fail at the Reducer step — but the
+        // FAILURE MODE differs from insertHyperlink: wrapWithHyperlink's
+        // emission produces removeNode + addRelationship + a placeholder
+        // insertNode, all of which still throw malformedOp("Phase 2c").
+        let (doc, runID) = makeFixture()
+        let url = URL(string: "https://example.com")!
+        let range = WordRange(startRun: runID, startOffset: 0, endRun: runID, endOffset: 6)
+        let edit = WordEdit.applyLink(range: range, url: url)
+
+        XCTAssertThrowsError(try doc.apply(edit)) { error in
+            guard case EditError.operationLogFailure = error else {
+                XCTFail("Expected .operationLogFailure (wrapWithHyperlink Reducer pending), got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/Tests/OOXMLSwiftTests/OperationLogTests.swift
+++ b/Tests/OOXMLSwiftTests/OperationLogTests.swift
@@ -20,10 +20,11 @@ final class OperationLogTests: XCTestCase {
 
     // MARK: - 1. Operation enum exhaustive case coverage
 
-    /// **Decision pinned**: `Operation` has 22 cases (16 element-level + 4
-    /// tree-node-level + 1 rels-part + 1 unknown). Each constructs and
-    /// pattern-matches. Updated in macdoc#110 §5 to add `addRelationship`
-    /// for typed rels-part mutations (see Operation.swift docstring).
+    /// **Decision pinned**: `Operation` has 23 cases (16 element-level + 4
+    /// tree-node-level + 1 sibling-relative + 1 rels-part + 1 unknown).
+    /// Each constructs and pattern-matches. Updated in ooxml-swift#71
+    /// Phase 2c to add `insertSiblingAfter` (typed sibling primitive used
+    /// by OOXMLEdit.insertHyperlink — see Operation.swift docstring).
     func testOperationEnumEachCaseConstructsAndMatches() {
         let id = ElementID(rawString: "w14:paraId=A")
         let id2 = ElementID(rawString: "w14:paraId=B")
@@ -50,6 +51,7 @@ final class OperationLogTests: XCTestCase {
             .removeNode(target: id),
             .updateAttribute(target: id, prefix: "w", localName: "id", value: "5"),
             .moveNode(source: id, destinationParent: id2, destinationIndex: 0),
+            .insertSiblingAfter(after: id, nodeXML: "<w:t>x</w:t>"),
             .addRelationship(
                 part: "word/_rels/document.xml.rels",
                 id: "rId99",
@@ -60,7 +62,7 @@ final class OperationLogTests: XCTestCase {
             .unknown(opType: "future", payload: JSONValue.object(["k": JSONValue.int(1)]))
         ]
 
-        XCTAssertEqual(cases.count, 22, "Operation MUST have exactly 22 cases enumerated in the test")
+        XCTAssertEqual(cases.count, 23, "Operation MUST have exactly 23 cases enumerated in the test")
 
         // Pattern-match: each case maps to its expected discriminator.
         for op in cases {
@@ -73,6 +75,7 @@ final class OperationLogTests: XCTestCase {
                  .undo, .redo,
                  .batchBegin, .batchEnd,
                  .insertNode, .removeNode, .updateAttribute, .moveNode,
+                 .insertSiblingAfter,
                  .addRelationship,
                  .unknown:
                 break // matched


### PR DESCRIPTION
## Summary

First incremental slice of remaining [ooxml-swift#71](https://github.com/PsychQuant/ooxml-swift/issues/71) Phase 2c work — unblocks `OOXMLEdit.insertHyperlink` **end-to-end** (insert semantics). The macdoc#110 §5 emission shipped a few PRs ago; this PR makes it actually mutate trees.

## What ships

### Operation enum (1 new typed case)

```swift
case insertSiblingAfter(after: ElementID, nodeXML: String)
```

Cleaner primitive than `insertNode` for sibling-relative insertion. Caller passes target ElementID; Reducer walks tree to find target's parent + index. Used by `OOXMLEdit.insertHyperlink` (was incorrectly using `insertNode` with semantically wrong `parent=target` argument).

Operation count: **22 → 23**.

### Reducer impls (2 new cases)

| Case | Logic |
|---|---|
| `insertSiblingAfter` | `findParentAndIndex(target)` → parse `nodeXML` fragment via new `parseXMLFragment()` helper → insert at index+1 |
| `addRelationship` | Append `<Relationship Id Type Target TargetMode>` to tree root's children. Pre-validates tree root is `<Relationships>` element |

### `WordDocument.apply` part routing

`addRelationship` is **part-addressed** (not ElementID-addressed), so apply needs special routing:
- Reads op's part path from payload (not via `partContaining`)
- Creates rels part on-demand via new `makeEmptyRelationshipsTree()` if it doesn't exist (synthesized fixtures often don't have rels parts)

### Internal helper

```swift
OperationReducer.parseXMLFragment(_ String) throws -> XmlNode
```

Wraps fragment with synthetic root carrying OOXML namespace decls (w, r, w14), parses via `XmlTreeReader`, returns the first element child. Reusable by future Phase 2c cases.

### OOXMLEdit.insertHyperlink emission fix

```swift
// Before (semantically incorrect):
.insertNode(parent: target, position: -1, nodeXML: ...)

// After (clean typed primitive):
.insertSiblingAfter(after: target, nodeXML: ...)
```

The old emission was wrong — target is a Run, not the parent. Reducer would have needed to interpret `parent: X` as "previous-sibling reference" which is overloaded. The new typed primitive is cleaner.

## Test coverage

4 new e2e tests in `InsertHyperlinkE2ETests.swift`:

| Test | What it verifies |
|---|---|
| `testInsertHyperlinkAddsWrapperAfterTargetRun` | Full xmlTrees mutation: paragraph has `[original run, hyperlink wrapper]` in order |
| `testInsertHyperlinkCreatesRelsPartOnDemand` | `word/_rels/document.xml.rels` auto-created with `<Relationship>` entry whose `Id` matches hyperlink's `r:id` (referential integrity) |
| `testInsertHyperlinkNilDisplayTextFallsBackToHref` | Pins §5 Q4 verdict (nil → href.absoluteString) |
| `testApplyLinkStillThrowsAtWrapReducer` | WordEdit.applyLink (lowers to wrapWithHyperlink) still throws; wrapWithHyperlink Reducer ships in follow-up |

`OperationLogTests` updated: 22 → 23 cases.

Full ooxml-swift suite: **1066 pass / 2 skipped / 0 fail** (was 1062 +4 from new tests).

## Architectural milestone

`OOXMLEdit.insertHyperlink` is now **FULLY FUNCTIONAL end-to-end**: emission, multi-part scoping, log persistence, materialize, both `document.xml` AND rels-part mutations. The full chain `Edit → lower → operations → log → materialize → new WordDocument` works for an OOXMLEdit case with **composite cross-part atomic semantics** — the hardest case in the §5 design walkthrough.

The cross-part referential integrity (hyperlink's `r:id` matches Relationship's `Id`) is verified by test — no special atomicity infrastructure needed, just deterministic rId allocation at emission time.

## Remaining ooxml-swift#71 work (post this PR)

| Priority | Case | Notes |
|---|---|---|
| HIGH | `wrapWithHyperlink` Reducer | OOXMLEdit.wrapWithHyperlink (Design Y); WordEdit.applyLink blocked on this |
| MEDIUM | `insertNode` Reducer | Generic primitive; not directly used by §5 anymore |
| MEDIUM | `removeNode` Reducer | Generic primitive |
| MEDIUM | `updateAttribute` Reducer | Generic primitive (rels uses `addRelationship` instead) |
| MEDIUM | `setRunFormat` italic/underline/etc. | Add when corresponding OOXMLEdit ships |
| LOW | tables, bookmarks, comments, etc. | Deferrable |

Refs PsychQuant/ooxml-swift#71
Refs PsychQuant/macdoc#105
Refs PsychQuant/macdoc#110
