### PR TITLE
feat(OpLog/Phase 2c): wrapWithHyperlink reducer — unblocks WordEdit.applyLink end-to-end (#71)

### DIFF
--- a/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
+++ b/Sources/OOXMLSwift/EditAlgebra/OOXMLEdit+Operation.swift
@@ -78,20 +78,19 @@ extension OOXMLEdit {
             ]
 
         case .wrapWithHyperlink(let target, let href):
-            // Wrap semantics: <w:hyperlink> takes target's position in
-            // parent. Reducer treats insertNode at position -1 with
-            // nodeXML containing a placeholder for the original target as
-            // "wrap target with this XML". Then removeNode removes the
-            // original position. (Two-op formulation; reducer may fuse.)
+            // Wrap semantics: Reducer wraps target with
+            // <w:hyperlink r:id=\"rId\">target</w:hyperlink> as a single
+            // atomic operation (Operation.wrapWithHyperlink typed primitive,
+            // ooxml-swift#71 Phase 2c slice 3). Plus addRelationship for
+            // the rels-part entry.
             //
-            // NOTE: target MUST be a <w:r>. Pre-validation in apply
-            // verifies this; if it's a paragraph or other element, apply
-            // throws EditError.unsupportedOperation.
+            // Updated from the original placeholder-substitution design
+            // ([insertNode + removeNode] with \$TARGET sentinel) to the
+            // cleaner typed primitive — Reducer constructs the wrapper
+            // internally with the deep-cloned target as its child.
             let rId = freshRelationshipId()
-            let hyperlinkOpenXML = renderHyperlinkOpenWithPlaceholder(rId: rId)
             return [
-                .insertNode(parent: target, position: -1, nodeXML: hyperlinkOpenXML),
-                .removeNode(target: target),
+                .wrapWithHyperlink(target: target, rId: rId),
                 .addRelationship(
                     part: documentRelsPath,
                     id: rId,
@@ -133,14 +132,6 @@ extension OOXMLEdit {
             "<w:t>\(escaped)</w:t>" +
             "</w:r>" +
             "</w:hyperlink>"
-    }
-
-    /// Renders the `<w:hyperlink>` wrapper for `wrapWithHyperlink` (wrap
-    /// semantics — wrapper has a placeholder marker; reducer fills in the
-    /// wrapped target). The "$TARGET" placeholder is a sentinel the
-    /// Phase 2c Reducer interprets to mean "the node being wrapped".
-    internal func renderHyperlinkOpenWithPlaceholder(rId: String) -> String {
-        return "<w:hyperlink r:id=\"\(rId)\">$TARGET</w:hyperlink>"
     }
 
     /// XML-escapes character content (text inside elements). Only handles

--- a/Sources/OOXMLSwift/OpLog/Operation.swift
+++ b/Sources/OOXMLSwift/OpLog/Operation.swift
@@ -62,6 +62,23 @@ public enum Operation: Equatable, Sendable {
     /// fragment wrapped with namespace declarations).
     case insertSiblingAfter(after: ElementID, nodeXML: String)
 
+    /// Wraps `target` element with a `<w:hyperlink r:id="rId">` wrapper.
+    /// The Reducer:
+    ///   1. Finds target's parent + index
+    ///   2. Deep-clones target
+    ///   3. Builds `<w:hyperlink r:id="rId">` element with the clone as child
+    ///   4. Replaces parent.children[idx] with the wrapper
+    ///
+    /// Atomic single-op — avoids the placeholder substitution problem of
+    /// `[insertNode + removeNode]` decomposition. Used by
+    /// `OOXMLEdit.wrapWithHyperlink` and (downstream) by
+    /// `WordEdit.applyLink` for Cmd-K parity.
+    ///
+    /// `rId` must match the Id in a paired `addRelationship` op (caller's
+    /// responsibility) for referential integrity between document.xml
+    /// and the rels part.
+    case wrapWithHyperlink(target: ElementID, rId: String)
+
     // MARK: Rels-part operations (typed)
 
     /// Adds a `<Relationship Id="..." Type="..." Target="..." TargetMode="..."/>`

--- a/Sources/OOXMLSwift/OpLog/OperationLog+JSONL.swift
+++ b/Sources/OOXMLSwift/OpLog/OperationLog+JSONL.swift
@@ -235,6 +235,11 @@ internal enum JSONLLineCoder {
                 ("after", jsonString(after.raw)),
                 ("nodeXML", jsonString(nodeXML))
             ])
+        case .wrapWithHyperlink(let target, let rId):
+            return ("wrapWithHyperlink", [
+                ("target", jsonString(target.raw)),
+                ("rId", jsonString(rId))
+            ])
         case .addRelationship(let part, let id, let type, let target, let targetMode):
             return ("addRelationship", [
                 ("part", jsonString(part)),
@@ -347,6 +352,8 @@ internal enum JSONLLineCoder {
             return .moveNode(source: try eid("source"), destinationParent: try eid("destinationParent"), destinationIndex: try int("destinationIndex"))
         case "insertSiblingAfter":
             return .insertSiblingAfter(after: try eid("after"), nodeXML: try str("nodeXML"))
+        case "wrapWithHyperlink":
+            return .wrapWithHyperlink(target: try eid("target"), rId: try str("rId"))
         case "addRelationship":
             return .addRelationship(
                 part: try str("part"),

--- a/Sources/OOXMLSwift/OpLog/OperationReducer.swift
+++ b/Sources/OOXMLSwift/OpLog/OperationReducer.swift
@@ -285,6 +285,28 @@ public enum OperationReducer {
                 )
             }
 
+        case .wrapWithHyperlink(let target, let rId):
+            // Wrap target with <w:hyperlink r:id="rId">...</w:hyperlink>.
+            // Cmd-K semantics: target stays in place but is now nested
+            // inside a hyperlink wrapper at target's original position.
+            // Used by OOXMLEdit.wrapWithHyperlink (via WordEdit.applyLink
+            // single-Run case).
+            guard let (parent, idx) = findParentAndIndex(targetID: target, in: tree.root) else {
+                throw ReducerError.elementNotFound(opID: entry.opID, elementID: target)
+            }
+            // Deep-clone target so the wrapper child is structurally
+            // separate from the original (we'll remove the original
+            // implicitly by replacing it in parent.children).
+            let clone = parent.children[idx].deepClone()
+            // Build <w:hyperlink r:id="rId">
+            let wrapper = XmlNode.element(prefix: "w", localName: "hyperlink")
+            wrapper.setAttribute(prefix: "r", localName: "id", value: rId)
+            wrapper.children = [clone]
+            // Replace target's position with the wrapper. (deepClone
+            // preserves target's libraryUUID, so future ops addressing
+            // target now resolve to the clone inside the wrapper.)
+            parent.children[idx] = wrapper
+
         case .addRelationship(let part, let id, let type, let target, let targetMode):
             // Append a <Relationship> entry to the specified rels part.
             // Rels-part xml has a fixed structure: <Relationships> root
@@ -545,6 +567,7 @@ public enum OperationReducer {
         case .updateAttribute(let target, _, _, _): return [target]
         case .moveNode(let source, let dest, _): return [source, dest]
         case .insertSiblingAfter(let after, _): return [after]
+        case .wrapWithHyperlink(let target, _): return [target]
         case .addRelationship:
             // Rels-part operations don't address an ElementID in any tree —
             // they target a part by path. WordDocument.apply's per-op
@@ -606,6 +629,7 @@ public enum OperationReducer {
         case .updateAttribute(let target, _, _, _): return target == elementID
         case .moveNode(let source, let dest, _): return source == elementID || dest == elementID
         case .insertSiblingAfter(let after, _): return after == elementID
+        case .wrapWithHyperlink(let target, _): return target == elementID
         case .addRelationship: return false  // rels-part operation, not element-addressed
         case .unknown: return false
         }

--- a/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertHyperlinkE2ETests.swift
+++ b/Tests/OOXMLSwiftTests/EditAlgebraTests/InsertHyperlinkE2ETests.swift
@@ -149,25 +149,77 @@ final class InsertHyperlinkE2ETests: XCTestCase {
                        "Nil displayText falls back to href.absoluteString per §5 Q4 verdict")
     }
 
-    // MARK: - WordEdit.applyLink stays gated on wrapWithHyperlink Reducer
+    // MARK: - wrapWithHyperlink end-to-end (via OOXMLEdit + via WordEdit.applyLink)
 
-    func testApplyLinkStillThrowsAtWrapReducer() {
-        // WordEdit.applyLink lowers to OOXMLEdit.wrapWithHyperlink (per
-        // Design Y), whose Reducer support is NOT in this PR. End-to-end
-        // applyLink continues to fail at the Reducer step — but the
-        // FAILURE MODE differs from insertHyperlink: wrapWithHyperlink's
-        // emission produces removeNode + addRelationship + a placeholder
-        // insertNode, all of which still throw malformedOp("Phase 2c").
+    func testWrapWithHyperlinkReplacesTargetWithWrappedRun() throws {
         let (doc, runID) = makeFixture()
-        let url = URL(string: "https://example.com")!
+        let url = URL(string: "https://example.com/wrap")!
+
+        let edit = OOXMLEdit.wrapWithHyperlink(target: runID, href: url)
+        let result = try doc.apply(edit)
+
+        // The paragraph now contains the hyperlink wrapper directly
+        // (not as a sibling — Wrap REPLACES target's position).
+        let docTree = result.xmlTrees["word/document.xml"]!
+        let para = docTree.root
+            .children.first { $0.kind == .element && $0.localName == "body" }!
+            .children.first { $0.kind == .element && $0.localName == "p" }!
+
+        let paraChildren = para.children.filter { $0.kind == .element }
+        XCTAssertEqual(paraChildren.count, 1,
+                       "After wrap: paragraph has exactly 1 element child (the hyperlink wrapper)")
+        XCTAssertEqual(paraChildren[0].localName, "hyperlink",
+                       "That child IS the hyperlink wrapper, not a sibling Run")
+
+        // Wrapper's r:id matches the rels entry's Id (referential integrity)
+        let wrapper = paraChildren[0]
+        let wrapperRId = wrapper.attributeValue(prefix: "r", localName: "id")
+        XCTAssertNotNil(wrapperRId)
+
+        let relsTree = result.xmlTrees["word/_rels/document.xml.rels"]
+        XCTAssertNotNil(relsTree, "Rels part auto-created")
+        let relationship = relsTree?.root.children.first {
+            $0.kind == .element && $0.localName == "Relationship"
+        }
+        let relsId = relationship?.attributeValue(prefix: nil, localName: "Id")
+        XCTAssertEqual(wrapperRId, relsId,
+                       "Wrapper's r:id matches rels Relationship's Id (referential integrity)")
+
+        // The wrapped run is INSIDE the hyperlink and preserves the original text
+        let innerRun = wrapper.children.first { $0.kind == .element && $0.localName == "r" }
+        XCTAssertNotNil(innerRun, "Hyperlink wraps a <w:r>")
+        let innerText = innerRun?.children.first { $0.kind == .element && $0.localName == "t" }?
+            .children.first { $0.kind == .text }?.textContent
+        XCTAssertEqual(innerText, "before",
+                       "Wrapped run preserves the original run's text content")
+    }
+
+    func testWordEditApplyLinkSingleRunEndToEnd() throws {
+        // WordEdit.applyLink lowers to OOXMLEdit.wrapWithHyperlink (Design Y).
+        // With wrapWithHyperlink Reducer now functional, applyLink works
+        // end-to-end. This proves the full chain: WordEdit semantic-layer →
+        // lower → OOXMLEdit syntactic-layer → operations → log → materialize.
+        let (doc, runID) = makeFixture()
+        let url = URL(string: "https://example.com/applylink")!
         let range = WordRange(startRun: runID, startOffset: 0, endRun: runID, endOffset: 6)
         let edit = WordEdit.applyLink(range: range, url: url)
 
-        XCTAssertThrowsError(try doc.apply(edit)) { error in
-            guard case EditError.operationLogFailure = error else {
-                XCTFail("Expected .operationLogFailure (wrapWithHyperlink Reducer pending), got \(error)")
-                return
-            }
+        let result = try doc.apply(edit)
+
+        // Verify the wrap happened
+        let docTree = result.xmlTrees["word/document.xml"]!
+        let para = docTree.root
+            .children.first { $0.kind == .element && $0.localName == "body" }!
+            .children.first { $0.kind == .element && $0.localName == "p" }!
+        let hyperlink = para.children.first { $0.kind == .element && $0.localName == "hyperlink" }
+        XCTAssertNotNil(hyperlink, "applyLink produced <w:hyperlink> wrapping the run")
+
+        // Rels entry exists with the right URL
+        let relsTree = result.xmlTrees["word/_rels/document.xml.rels"]
+        let rel = relsTree?.root.children.first {
+            $0.kind == .element && $0.localName == "Relationship"
         }
+        XCTAssertEqual(rel?.attributeValue(prefix: nil, localName: "Target"),
+                       "https://example.com/applylink")
     }
 }

--- a/Tests/OOXMLSwiftTests/OperationLogTests.swift
+++ b/Tests/OOXMLSwiftTests/OperationLogTests.swift
@@ -20,11 +20,12 @@ final class OperationLogTests: XCTestCase {
 
     // MARK: - 1. Operation enum exhaustive case coverage
 
-    /// **Decision pinned**: `Operation` has 23 cases (16 element-level + 4
-    /// tree-node-level + 1 sibling-relative + 1 rels-part + 1 unknown).
-    /// Each constructs and pattern-matches. Updated in ooxml-swift#71
-    /// Phase 2c to add `insertSiblingAfter` (typed sibling primitive used
-    /// by OOXMLEdit.insertHyperlink — see Operation.swift docstring).
+    /// **Decision pinned**: `Operation` has 24 cases (16 element-level + 4
+    /// tree-node-level + 1 sibling-relative + 1 wrap-with-hyperlink +
+    /// 1 rels-part + 1 unknown). Each constructs and pattern-matches.
+    /// Updated in ooxml-swift#71 Phase 2c to add `insertSiblingAfter`
+    /// and `wrapWithHyperlink` (typed primitives for hyperlink composite
+    /// emission — see Operation.swift docstrings).
     func testOperationEnumEachCaseConstructsAndMatches() {
         let id = ElementID(rawString: "w14:paraId=A")
         let id2 = ElementID(rawString: "w14:paraId=B")
@@ -52,6 +53,7 @@ final class OperationLogTests: XCTestCase {
             .updateAttribute(target: id, prefix: "w", localName: "id", value: "5"),
             .moveNode(source: id, destinationParent: id2, destinationIndex: 0),
             .insertSiblingAfter(after: id, nodeXML: "<w:t>x</w:t>"),
+            .wrapWithHyperlink(target: id, rId: "rId99"),
             .addRelationship(
                 part: "word/_rels/document.xml.rels",
                 id: "rId99",
@@ -62,7 +64,7 @@ final class OperationLogTests: XCTestCase {
             .unknown(opType: "future", payload: JSONValue.object(["k": JSONValue.int(1)]))
         ]
 
-        XCTAssertEqual(cases.count, 23, "Operation MUST have exactly 23 cases enumerated in the test")
+        XCTAssertEqual(cases.count, 24, "Operation MUST have exactly 24 cases enumerated in the test")
 
         // Pattern-match: each case maps to its expected discriminator.
         for op in cases {
@@ -76,6 +78,7 @@ final class OperationLogTests: XCTestCase {
                  .batchBegin, .batchEnd,
                  .insertNode, .removeNode, .updateAttribute, .moveNode,
                  .insertSiblingAfter,
+                 .wrapWithHyperlink,
                  .addRelationship,
                  .unknown:
                 break // matched


### PR DESCRIPTION
## Summary

Third incremental slice of [ooxml-swift#71](https://github.com/PsychQuant/ooxml-swift/issues/71) Phase 2c work. Unblocks `OOXMLEdit.wrapWithHyperlink` AND `WordEdit.applyLink` end-to-end (Cmd-K parity).

## What ships

### Operation enum (1 new typed case)

```swift
case wrapWithHyperlink(target: ElementID, rId: String)
```

Cmd-K semantics primitive. Reducer wraps target with `<w:hyperlink r:id="rId">target</w:hyperlink>` as a single atomic operation. Replaces the original 3-op emission (`insertNode + removeNode + addRelationship` with `$TARGET` placeholder substitution) which was architecturally messy.

Operation count: **23 → 24**.

### Reducer impl

```
1. findParentAndIndex(target)
2. parent.children[idx].deepClone()         ← preserves target's libraryUUID
3. Build <w:hyperlink r:id="rId">; set deep-clone as child
4. parent.children[idx] = wrapper           ← replaces in place
```

After this op, future operations addressing `target` by ElementID resolve to the **clone inside the wrapper** (deepClone preserves libraryUUID, so the addressing chain stays intact).

### OOXMLEdit.wrapWithHyperlink emission update

```swift
// Before:
[insertNode (with $TARGET placeholder), removeNode, addRelationship]

// Now:
[wrapWithHyperlink (typed), addRelationship]
```

Dead code removed: `renderHyperlinkOpenWithPlaceholder` helper (placeholder mechanism gone).

## Test coverage

2 new e2e tests:

| Test | What it verifies |
|---|---|
| `testWrapWithHyperlinkReplacesTargetWithWrappedRun` | OOXMLEdit-level e2e: paragraph has 1 element child (the hyperlink), wrapped run is INSIDE preserving original text, rels referential integrity |
| `testWordEditApplyLinkSingleRunEndToEnd` | WordEdit-level e2e: applyLink → lower → wrapWithHyperlink → operations → materialize → trees mutated |

Removed `testApplyLinkStillThrowsAtWrapReducer` (was asserting applyLink fails; now succeeds).

`OperationLogTests` updated: 23 → 24 cases.

Full ooxml-swift suite: **1067 pass / 2 skipped / 0 fail**.

## Architectural milestone

**`WordEdit.applyLink` is now FULLY FUNCTIONAL end-to-end** for single-Run cases (the typical Cmd-K UX). The semantic-layer Edit → syntactic-layer Edit → tree mutation chain is proven for the wrap-existing case.

Multi-Run case still gated on `lower()` doc-context constraint (per §7); that's a protocol-level concern, not a Reducer concern.

## State summary

All 5 OOXMLEdit cases shipped from #105/#110 now have functional Reducer support:

| OOXMLEdit case | End-to-end status |
|---|---|
| `insertParagraph` | ✓ Functional (PR #72) |
| `insertParagraphBefore` | ✓ Functional (PR #72) |
| `setBold` | ✓ Functional — bold MVP (PR #72) |
| `removeParagraph` | ✓ Functional (PR #72) |
| `insertHyperlink` | ✓ Functional (PR #81) |
| **`wrapWithHyperlink`** | **✓ Functional (this PR)** |

All 3 WordEdit cases functional:

| WordEdit case | End-to-end status |
|---|---|
| `applyBold` (single-Run) | ✓ Functional |
| `applyInsertParagraph` | ✓ Functional |
| **`applyLink` (single-Run)** | **✓ Functional (this PR — Cmd-K parity)** |

## Remaining ooxml-swift#71 work (post this PR)

All remaining Reducer cases are generic primitives that aren't currently emitted by any OOXMLEdit — safe to defer:

| Priority | Case | Notes |
|---|---|---|
| MEDIUM | `insertNode` (generic) | Not in any OOXMLEdit emission anymore |
| MEDIUM | `removeNode` (generic) | Same |
| MEDIUM | `updateAttribute` (generic) | Same |
| MEDIUM | `setRunFormat` italic/underline/etc. | Add when corresponding OOXMLEdit ships |
| MEDIUM | `redo` + extended `applyInverse` | Undo for tree-mutating ops |
| LOW | `insertTable` / `removeTable` / `setCellText` | No current OOXMLEdit lowering |
| LOW | `insertRun` | No current OOXMLEdit lowering |
| LOW | `insertBookmark` / `insertComment` | Multi-part — speculative |

Refs PsychQuant/ooxml-swift#71
Refs PsychQuant/macdoc#105
Refs PsychQuant/macdoc#110
